### PR TITLE
Implement v810's instruction cache and part of the CHCW system register

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 
 #[derive(Debug, Clone)]
 pub enum Command {
+    ShowCpuCache,
     ShowRegs,
     Step,
     Continue,
@@ -40,6 +41,7 @@ named!(
     complete!(
         terminated!(
         alt_complete!(
+            show_cpu_cache|
             step |
             continue_ |
             goto |
@@ -58,6 +60,12 @@ named!(
             show_regs |
             repeat),
         eof)));
+
+named!(
+    show_cpu_cache<Command>,
+    map!(
+        alt_complete!(tag!("showcpucache") | tag!("scc")),
+    |_| Command::ShowCpuCache));
 
 named!(
     step<Command>,

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -230,6 +230,15 @@ impl Emulator {
                     println!("eipsw: 0x{:08x}", self.virtual_boy.cpu.reg_eipsw());
                     println!("ecr: 0x{:08x}", self.virtual_boy.cpu.reg_ecr());
                 }
+                Ok(Command::ShowCpuCache) => {
+                    println!("CPU Instruction Cached enable: {}", self.virtual_boy.cpu.cache.is_enabled());
+                    let (hits, misses) = self.virtual_boy.cpu.cache.stats();
+                    let percent_hit = (hits as f64 / (hits + misses) as f64) * 100.0;
+                    println!("Cache Hits: {}, Cache Misses: {} ({:.1}% hit rate)", hits, misses, percent_hit);
+                    for i in 0..128 {
+                        println!("Entry {:3}: {}", i, self.virtual_boy.cpu.cache.entry(i));
+                    }
+                },
                 Ok(Command::Step) => {
                     self.step(video_frame_sink, audio_frame_sink);
                     self.cursor = self.virtual_boy.cpu.reg_pc();


### PR DESCRIPTION
The v810 cpu has a 1k direct-mapping instruction cache that's broken up
in to 128x 8 byte blocks.  Each 8 byte block is further broken up in to
2x 4 byte subblocks.

The instruction cache implementation only keeps track of which memory
addresses would be cached and not any actual instruction data.  All
halfword instruction reads were replaced with a wrapper function that
returns the halfword and a bool if the read would have been cached or
not.  Nothing is currently being done with the cached bool result other
then stop rust for throwing a dead_code notice.  So there should be no
real visual/audio change to emulation until its hooked in better.

showcpucache command was added to the debugger to dump the contents of
the cache and some basic stats on hits/misses.

The CHCW system register implementation supports being able to
enable/disable the cpu instruction cache as well as being able to clear
entries within the cache.  This leaves being able to dump/restore the
cache from ram missing.

Both implementations are based on info provided in the v810 architecture
user's manual (U10082EJ1V0UM00.pdf).  Chapter 7 for cpu instruction
cache and chapter 2 (2.2.3) for CHCW.