### PR TITLE
Adjust sweep modification period.

### DIFF
--- a/src/vsu/mod.rs
+++ b/src/vsu/mod.rs
@@ -23,8 +23,8 @@ const FREQUENCY_CLOCK_PERIOD: usize = 4;
 // 20mhz / 1041.6hz = ~19200 clocks
 const SWEEP_MOD_SMALL_PERIOD: usize = 19200;
 
-// 20mhz / 130.2hz = ~153610 clocks
-const SWEEP_MOD_LARGE_PERIOD: usize = 153610;
+// 20mhz / 130.2hz = ~153600 clocks
+const SWEEP_MOD_LARGE_PERIOD: usize = 153600;
 
 // 20mhz / 500khz = 40 clocks
 const NOISE_CLOCK_PERIOD: usize = 40;


### PR DESCRIPTION
You said in the Ep.019 stream (at around 01:13:30) that these timer interval - clock tick count numbers are weird, but kind of round.

Now, if we divide 19200 by 100, the result in binary will have exactly two ones in it next to each other. It's a nice, simple, round number, looking at it this way.
This is not true for 153610, but it is for 153600, hence my guess that it would be the correct number.
This in itself looks like it could let the actual hardware be simpler when checking for these two particular numbers.

Another reason why I think this might be closer is that
20e6 / 19200 is 1041.6 recurring, which is about 0.0064 percent off of the (most likely rounded) figure in the documentation, 1041.6 (not recurring).
20e6 / 153600 is 130.2083 recurring, which has the same 0.0064 percent error compared to the 130.2 in the docs. Unlike 153610.

However, please note that this is entirely a shot in the dark, so I understand if you don't trust my intuition without further proof, but to me, it seemed totally logical.