### PR TITLE
Command line refinement

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -7,6 +7,9 @@ distributions of Rustual Boy:
 * bitflags - https://github.com/rust-lang-nursery/bitflags/blob/master/LICENSE-MIT
 * log - https://github.com/rust-lang-nursery/log/blob/master/LICENSE-MIT
 * time - https://github.com/rust-lang-deprecated/time/blob/master/LICENSE-MIT
+* unicode-segmentation - https://github.com/unicode-rs/unicode-segmentation/blob/master/LICENSE-MIT
+* unicode-width - https://github.com/unicode-rs/unicode-width/blob/master/LICENSE-MIT
+* vec_map - https://github.com/contain-rs/vec-map/blob/master/LICENSE-MIT
 
     Copyright (c) 2014 The Rust Project Developers
 
@@ -585,3 +588,75 @@ distributions of Rustual Boy:
         party to this document and has no duty or obligation with respect to
         this CC0 or use of the Work.
 
+* ansi_term - https://github.com/ogham/rust-ansi-term/blob/master/LICENCE
+
+    The MIT License (MIT)
+
+    Copyright (c) 2014 Benjamin Sago
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+* clap - https://github.com/kbknapp/clap-rs/blob/master/LICENSE-MIT
+* term_size - https://github.com/kbknapp/term_size-rs/blob/master/LICENSE-MIT
+
+    The MIT License (MIT)
+
+    Copyright (c) 2015-2016 Kevin B. Knapp
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+* strsim - https://github.com/dguo/strsim-rs/blob/master/LICENSE
+
+    The MIT License (MIT)
+
+    Copyright (c) 2015 Danny Guo
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/rustual-boy-cli/Cargo.lock
+++ b/rustual-boy-cli/Cargo.lock
@@ -2,6 +2,7 @@
 name = "rustual-boy-cli"
 version = "0.1.0"
 dependencies = [
+ "clap 2.20.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpal 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -20,9 +21,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "coreaudio-rs"
@@ -227,6 +248,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "term_size"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "time"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +274,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "user32-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +291,11 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
@@ -267,7 +318,9 @@ dependencies = [
 
 [metadata]
 "checksum alsa-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2c3f84e271f1613d7d7cbf6608beaed341c3f3d7e57045a6fc1a7d112380613c"
+"checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum clap 2.20.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f89819450aa94325998aa83ce7ea142db11ad24c725d6bc48459845e0d6d9f18"
 "checksum coreaudio-rs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a633fa29946681f8c98ad593c00a84189961970a01e317b054cdd7628794f7f"
 "checksum coreaudio-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31231897622a4cd14cb211af6f26d6fcf0c78078fa60c586ce9db8f0b581cd44"
 "checksum cpal 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c67b9a47bedd902a13a1ec3f2e73be4e19b589c28a174ba1c52f50379c9ca05c"
@@ -293,8 +346,13 @@ dependencies = [
 "checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
+"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum term_size 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "71662702fe5cd2cf95edd4ad655eea42f24a87a0e44059cbaa4e55260b7bc331"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
+"checksum unicode-segmentation 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3c5336c5173d8a77ae0b36151c706e32ae10f4985e29d704ad5b5f9565d6d4b6"
+"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6717129de5ac253f5642fc78a51d0c7de6f9f53d617fc94e9bae7f6e71cf5504"
+"checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum x11-dl 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "349db8b7b8be6031ac00cb49ac8b8389e5e1b1743300d2873223be80d35fd216"

--- a/rustual-boy-cli/Cargo.toml
+++ b/rustual-boy-cli/Cargo.toml
@@ -18,3 +18,4 @@ minifb = "0.9.0"
 cpal = "0.4.4"
 futures = "0.1.1"
 rustual-boy-core = { path = "../rustual-boy-core" }
+clap = "2.0.0"

--- a/rustual-boy-cli/src/argparse.rs
+++ b/rustual-boy-cli/src/argparse.rs
@@ -21,12 +21,15 @@ pub fn parse_args() -> CommandLineConfig {
         );
 
     let matches = app.get_matches();
+    //
+    // unwrap is safe here becuase clap guarantees that required arguments are never None
+    let rom_path = matches.value_of("ROM").unwrap();
 
     CommandLineConfig {
-        rom_path: matches.value_of("ROM").unwrap().into(),
+        rom_path: rom_path.into(),
         sram_path: match matches.value_of("SRAM") {
             Some(v) => v.into(),
-            None => matches.value_of("ROM").unwrap().replace(".vb", ".srm")
+            None => rom_path.replace(".vb", ".srm")
         },
     }
 }

--- a/rustual-boy-cli/src/argparse.rs
+++ b/rustual-boy-cli/src/argparse.rs
@@ -6,10 +6,10 @@ pub struct CommandLineConfig {
 }
 
 pub fn parse_args() -> CommandLineConfig {
-    let app = App::new("Rustual-boy")
+    let app = App::new("Rustual Boy")
         .version("0.1.0")
         .author(crate_authors!(", "))
-        .about("A CLI frontend to the rustual-boy emulator")
+        .about("A CLI frontend to the Rustual Boy emulator")
         .arg(Arg::with_name("ROM")
              .help("The name of the ROM to load")
              .required(true)

--- a/rustual-boy-cli/src/argparse.rs
+++ b/rustual-boy-cli/src/argparse.rs
@@ -14,12 +14,19 @@ pub fn parse_args() -> CommandLineConfig {
              .help("The name of the ROM to load")
              .required(true)
              .index(1)
+        ).arg(Arg::with_name("SRAM")
+              .help("Path to an SRAM")
+              .short("s")
+              .long("sram")
         );
 
     let matches = app.get_matches();
 
     CommandLineConfig {
         rom_path: matches.value_of("ROM").unwrap().into(),
-        sram_path: matches.value_of("ROM").unwrap().replace(".vb", ".srm").into()
+        sram_path: match matches.value_of("SRAM") {
+            Some(v) => v.into(),
+            None => matches.value_of("ROM").unwrap().replace(".vb", ".srm")
+        },
     }
 }

--- a/rustual-boy-cli/src/argparse.rs
+++ b/rustual-boy-cli/src/argparse.rs
@@ -1,0 +1,25 @@
+use clap::{App, Arg};
+
+pub struct CommandLineConfig {
+    pub rom_path: String,
+    pub sram_path: String,
+}
+
+pub fn parse_args() -> CommandLineConfig {
+    let app = App::new("Rustual-boy")
+        .version("0.1.0")
+        .author(crate_authors!(", "))
+        .about("A CLI frontend to the rustual-boy emulator")
+        .arg(Arg::with_name("ROM")
+             .help("The name of the ROM to load")
+             .required(true)
+             .index(1)
+        );
+
+    let matches = app.get_matches();
+
+    CommandLineConfig {
+        rom_path: matches.value_of("ROM").unwrap().into(),
+        sram_path: matches.value_of("ROM").unwrap().replace(".vb", ".srm").into()
+    }
+}

--- a/rustual-boy-cli/src/main.rs
+++ b/rustual-boy-cli/src/main.rs
@@ -9,8 +9,12 @@ extern crate cpal;
 
 extern crate futures;
 
+#[macro_use]
+extern crate clap;
+
 extern crate rustual_boy_core;
 
+mod argparse;
 #[macro_use]
 mod logging;
 mod command;
@@ -25,14 +29,12 @@ use rustual_boy_core::vsu::*;
 use cpal_driver::*;
 use emulator::*;
 
-use std::env;
-
 fn main() {
-    let rom_file_name = env::args().nth(1).unwrap();
+    let config = argparse::parse_args();
 
-    logln!("Loading ROM file {}", rom_file_name);
+    logln!("Loading ROM file {}", config.rom_path);
 
-    let rom = Rom::load(&rom_file_name).unwrap();
+    let rom = Rom::load(&config.rom_path).unwrap();
 
     log!("ROM size: ");
     if rom.size() >= 1024 * 1024 {
@@ -47,9 +49,8 @@ fn main() {
     logln!(" game code: \"{}\"", rom.game_code().unwrap());
     logln!(" game version: 1.{:#02}", rom.game_version_byte());
 
-    let sram_file_name = rom_file_name.replace(".vb", ".srm");
-    logln!("Attempting to load SRAM file: {}", sram_file_name);
-    let sram = match Sram::load(&sram_file_name) {
+    logln!("Attempting to load SRAM file: {}", config.sram_path);
+    let sram = match Sram::load(&config.sram_path) {
         Ok(sram) => {
             logln!(" SRAM loaded successfully");
 
@@ -71,7 +72,7 @@ fn main() {
     emulator.run();
 
     if emulator.virtual_boy.interconnect.sram.size() > 0 {
-        logln!("SRAM used, saving to {}", sram_file_name);
-        emulator.virtual_boy.interconnect.sram.save(sram_file_name).unwrap();
+        logln!("SRAM used, saving to {}", config.sram_path);
+        emulator.virtual_boy.interconnect.sram.save(config.sram_path).unwrap();
     }
 }


### PR DESCRIPTION
Use the `clap` library to parse command line arguments. Should make it easier to add new command line arguments. As an added bonus, it's now possible to independently specify the SRAM file name instead of having always be based upon the name of the ROM (though that's still the default).
Current help text:
```
Rustual-boy 0.1.0
ferris <yupferris@gmail.com>, The Rustual Boy contributors
A CLI frontend to the rustual-boy emulator

USAGE:
    rustual-boy-cli [FLAGS] <ROM>

FLAGS:
    -s, --sram       Path to an SRAM
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <ROM>    The name of the ROM to load
```