### PR TITLE
implement rev sub opcode

### DIFF
--- a/rustual-boy-core/src/instruction.rs
+++ b/rustual-boy-core/src/instruction.rs
@@ -79,6 +79,7 @@ pub const OPCODE_BITS_SUB_OP_MULF_S: u16 = 0b000110;
 pub const OPCODE_BITS_SUB_OP_DIVF_S: u16 = 0b000111;
 pub const OPCODE_BITS_SUB_OP_XB: u16 = 0b001000;
 pub const OPCODE_BITS_SUB_OP_XH: u16 = 0b001001;
+pub const OPCODE_BITS_SUB_OP_REV: u16 = 0b001010;
 pub const OPCODE_BITS_SUB_OP_TRNC_SW: u16 = 0b001011;
 pub const OPCODE_BITS_SUB_OP_MPYHW: u16 = 0b001100;
 
@@ -340,6 +341,7 @@ impl Opcode {
             OPCODE_BITS_SUB_OP_DIVF_S => SubOp::DivfS,
             OPCODE_BITS_SUB_OP_XB => SubOp::Xb,
             OPCODE_BITS_SUB_OP_XH => SubOp::Xh,
+            OPCODE_BITS_SUB_OP_REV => SubOp::Rev,
             OPCODE_BITS_SUB_OP_TRNC_SW => SubOp::TrncSw,
             OPCODE_BITS_SUB_OP_MPYHW => SubOp::Mpyhw,
             _ => panic!("Unrecognized subop bits: {:06b}", subop),
@@ -462,6 +464,7 @@ pub enum SubOp {
     DivfS,
     Xb,
     Xh,
+    Rev,
     TrncSw,
     Mpyhw,
 }
@@ -478,6 +481,7 @@ impl fmt::Display for SubOp {
             &SubOp::DivfS => "divf.s",
             &SubOp::Xb => "xb",
             &SubOp::Xh => "xh",
+            &SubOp::Rev => "rev",
             &SubOp::TrncSw => "trnc.sw",
             &SubOp::Mpyhw => "mpyhw",
         };

--- a/rustual-boy-core/src/nvc.rs
+++ b/rustual-boy-core/src/nvc.rs
@@ -822,6 +822,16 @@ impl Nvc {
                             let value = (original >> 16) | ((original & 0xffff) << 16);
                             self.set_reg_gpr(reg2, value);
                         }
+                        OPCODE_BITS_SUB_OP_REV => {
+                            let original = self.reg_gpr(reg1);
+                            let mut value: u32 = 0;
+                            for x in 0..32 {
+                                value = (value << 1) | ((original >> x) & 0x01);
+                            }
+                            self.set_reg_gpr(reg2, value);
+
+                            num_cycles = 22;
+                        }
                         OPCODE_BITS_SUB_OP_TRNC_SW => {
                             let value = (self.reg_gpr_float(reg1).trunc() as i32) as u32;
                             self.set_reg_gpr(reg2, value);


### PR DESCRIPTION
rev sub opcode takes the value in reg1 and reverses the bits, storing the
result in reg2.

http://www.planetvb.com/content/downloads/documents/stsvb.html#cpunintendoinstructions

The cycle count (22) for this instruction was pulled from

http://www.planetvb.com/modules/newbb/viewtopic.php?viewmode=flat&topic_id=5765&forum=2