### PR TITLE
[WIP] Initial implementation of middleware, supporting common mode anaglyph rendering

### DIFF
--- a/rustual-boy-cli/Cargo.lock
+++ b/rustual-boy-cli/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "minifb 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustual-boy-core 0.1.0",
+ "rustual-boy-middleware 0.1.0",
 ]
 
 [[package]]
@@ -245,6 +246,13 @@ name = "rustual-boy-core"
 version = "0.1.0"
 dependencies = [
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustual-boy-middleware"
+version = "0.1.0"
+dependencies = [
+ "rustual-boy-core 0.1.0",
 ]
 
 [[package]]

--- a/rustual-boy-cli/Cargo.toml
+++ b/rustual-boy-cli/Cargo.toml
@@ -17,5 +17,6 @@ nom = "^1.2.3"
 minifb = "0.9.0"
 cpal = "0.4.4"
 futures = "0.1.1"
+rustual-boy-middleware = { path = "../rustual-boy-middleware" }
 rustual-boy-core = { path = "../rustual-boy-core" }
 clap = "2.0.0"

--- a/rustual-boy-cli/src/cpal_driver.rs
+++ b/rustual-boy-cli/src/cpal_driver.rs
@@ -5,7 +5,7 @@ use cpal::{EventLoop, Voice, UnknownTypeBuffer, get_default_endpoint};
 use futures::stream::Stream;
 use futures::task::{self, Executor, Run};
 
-use rustual_boy_core::audio_buffer_sink::AudioBufferSink;
+use rustual_boy_core::sinks::{AudioBufferSink, SinkRef};
 use rustual_boy_core::time_source::TimeSource;
 
 use std::borrow::Cow;
@@ -56,7 +56,7 @@ struct CpalDriverBufferSink {
     ring_buffer: Arc<Mutex<RingBuffer>>,
 }
 
-impl AudioBufferSink for CpalDriverBufferSink {
+impl SinkRef<[(i16, i16)]> for CpalDriverBufferSink {
     fn append(&mut self, buffer: &[(i16, i16)]) {
         let mut ring_buffer = self.ring_buffer.lock().unwrap();
         for &(left, right) in buffer {
@@ -65,6 +65,8 @@ impl AudioBufferSink for CpalDriverBufferSink {
         }
     }
 }
+
+impl AudioBufferSink for CpalDriverBufferSink { }
 
 struct CpalDriverTimeSource {
     ring_buffer: Arc<Mutex<RingBuffer>>,

--- a/rustual-boy-cli/src/emulator.rs
+++ b/rustual-boy-cli/src/emulator.rs
@@ -142,21 +142,18 @@ impl Emulator {
                 }
             }
 
-            match video_frame_sink.into_inner().into_inner() {
-                Some(frame) => {
-                    let frame: Vec<u32> = frame.into_iter().map(|x| x.into()).collect();
-                    self.window.update_with_buffer(&frame);
+            if let Some(frame) = video_frame_sink.into_inner().into_inner() {
+                let frame: Vec<u32> = frame.into_iter().map(|x| x.into()).collect();
+                self.window.update_with_buffer(&frame);
 
-                    if self.mode == Mode::Running {
-                        // We only want to update the key state when a frame is actually pushed
-                        // Otherwise some games break.
-                        self.read_input_keys();
-                        if self.window.is_key_pressed(Key::F12, KeyRepeat::No) {
-                            self.start_debugger();
-                        }
+                if self.mode == Mode::Running {
+                    // We only want to update the key state when a frame is actually pushed
+                    // Otherwise some games break.
+                    self.read_input_keys();
+                    if self.window.is_key_pressed(Key::F12, KeyRepeat::No) {
+                        self.start_debugger();
                     }
-                },
-                None => {}
+                }
             }
 
             self.audio_buffer_sink.append(audio_frame_sink.inner.as_slices().0);

--- a/rustual-boy-cli/src/emulator.rs
+++ b/rustual-boy-cli/src/emulator.rs
@@ -2,7 +2,7 @@ use minifb::{WindowOptions, Window, Key, KeyRepeat, Scale};
 
 use command::*;
 
-use rustual_boy_core::sinks::{AudioBufferSink, AudioFrameSink, Sink, VideoFrameSink};
+use rustual_boy_core::sinks::{AudioFrame, Sink, SinkRef, VideoFrame};
 use rustual_boy_core::time_source::TimeSource;
 use rustual_boy_core::rom::Rom;
 use rustual_boy_core::sram::Sram;
@@ -22,16 +22,14 @@ use std::sync::mpsc::{channel, Receiver};
 const CPU_CYCLE_TIME_NS: u64 = 50;
 
 struct SimpleAudioFrameSink {
-    inner: VecDeque<(i16, i16)>,
+    inner: VecDeque<AudioFrame>,
 }
 
-impl Sink<(i16, i16)> for SimpleAudioFrameSink {
-    fn append(&mut self, frame: (i16, i16)) {
+impl Sink<AudioFrame> for SimpleAudioFrameSink {
+    fn append(&mut self, frame: AudioFrame) {
         self.inner.push_back(frame);
     }
 }
-
-impl AudioFrameSink for SimpleAudioFrameSink { }
 
 #[derive(PartialEq, Eq)]
 enum Mode {
@@ -54,7 +52,7 @@ pub struct Emulator {
     stdin_receiver: Receiver<String>,
     _stdin_thread: JoinHandle<()>,
 
-    audio_buffer_sink: Box<AudioBufferSink>,
+    audio_buffer_sink: Box<SinkRef<[AudioFrame]>>,
 
     time_source: Box<TimeSource>,
     time_source_start_time_ns: u64,
@@ -63,7 +61,7 @@ pub struct Emulator {
 }
 
 impl Emulator {
-    pub fn new(rom: Rom, sram: Sram, audio_buffer_sink: Box<AudioBufferSink>, time_source: Box<TimeSource>) -> Emulator {
+    pub fn new(rom: Rom, sram: Sram, audio_buffer_sink: Box<SinkRef<[AudioFrame]>>, time_source: Box<TimeSource>) -> Emulator {
         let (stdin_sender, stdin_receiver) = channel();
         let stdin_thread = thread::spawn(move || {
             loop {
@@ -162,7 +160,7 @@ impl Emulator {
         }
     }
 
-    fn step(&mut self, video_frame_sink: &mut VideoFrameSink, audio_frame_sink: &mut AudioFrameSink) -> (usize, bool) {
+    fn step(&mut self, video_frame_sink: &mut Sink<VideoFrame>, audio_frame_sink: &mut Sink<AudioFrame>) -> (usize, bool) {
         let ret = self.virtual_boy.step(video_frame_sink, audio_frame_sink);
 
         self.emulated_cycles += ret.0 as _;
@@ -196,7 +194,7 @@ impl Emulator {
         self.print_cursor();
     }
 
-    fn run_debugger_commands(&mut self, video_frame_sink: &mut VideoFrameSink, audio_frame_sink: &mut AudioFrameSink) -> bool {
+    fn run_debugger_commands(&mut self, video_frame_sink: &mut Sink<VideoFrame>, audio_frame_sink: &mut Sink<AudioFrame>) -> bool {
         while let Ok(command_string) = self.stdin_receiver.try_recv() {
             let command = match (command_string.parse(), self.last_command.clone()) {
                 (Ok(Command::Repeat), Some(c)) => Ok(c),

--- a/rustual-boy-cli/src/emulator.rs
+++ b/rustual-boy-cli/src/emulator.rs
@@ -2,9 +2,7 @@ use minifb::{WindowOptions, Window, Key, KeyRepeat, Scale};
 
 use command::*;
 
-use rustual_boy_core::video_frame_sink::VideoFrameSink;
-use rustual_boy_core::audio_buffer_sink::AudioBufferSink;
-use rustual_boy_core::audio_frame_sink::AudioFrameSink;
+use rustual_boy_core::sinks::{AudioBufferSink, AudioFrameSink, Sink, VideoFrameSink};
 use rustual_boy_core::time_source::TimeSource;
 use rustual_boy_core::rom::Rom;
 use rustual_boy_core::sram::Sram;
@@ -26,11 +24,13 @@ struct SimpleAudioFrameSink {
     inner: VecDeque<(i16, i16)>,
 }
 
-impl AudioFrameSink for SimpleAudioFrameSink {
+impl Sink<(i16, i16)> for SimpleAudioFrameSink {
     fn append(&mut self, frame: (i16, i16)) {
         self.inner.push_back(frame);
     }
 }
+
+impl AudioFrameSink for SimpleAudioFrameSink { }
 
 #[derive(PartialEq, Eq)]
 enum Mode {

--- a/rustual-boy-cli/src/main.rs
+++ b/rustual-boy-cli/src/main.rs
@@ -14,6 +14,8 @@ extern crate clap;
 
 extern crate rustual_boy_core;
 
+extern crate rustual_boy_middleware;
+
 mod argparse;
 #[macro_use]
 mod logging;

--- a/rustual-boy-cli/src/wave_file_buffer_sink.rs
+++ b/rustual-boy-cli/src/wave_file_buffer_sink.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use rustual_boy_core::audio_buffer_sink::AudioBufferSink;
+use rustual_boy_core::sinks::{AudioBufferSink, SinkRef};
 
 use std::io::{self, Write, Seek, SeekFrom, BufWriter};
 use std::fs::File;
@@ -80,7 +80,7 @@ impl Drop for WaveFileBufferSink {
     }
 }
 
-impl AudioBufferSink for WaveFileBufferSink {
+impl SinkRef<[(i16, i16)]> for WaveFileBufferSink {
     fn append(&mut self, buffer: &[(i16, i16)]) {
         for &(left, right) in buffer {
             self.write_u16(left as _).unwrap();
@@ -88,4 +88,7 @@ impl AudioBufferSink for WaveFileBufferSink {
             self.num_frames += 1;
         }
     }
+}
+
+impl AudioBufferSink for WaveFileBufferSink {
 }

--- a/rustual-boy-cli/src/wave_file_buffer_sink.rs
+++ b/rustual-boy-cli/src/wave_file_buffer_sink.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use rustual_boy_core::sinks::{AudioBufferSink, SinkRef};
+use rustual_boy_core::sinks::{AudioFrame, SinkRef};
 
 use std::io::{self, Write, Seek, SeekFrom, BufWriter};
 use std::fs::File;
@@ -80,7 +80,7 @@ impl Drop for WaveFileBufferSink {
     }
 }
 
-impl SinkRef<[(i16, i16)]> for WaveFileBufferSink {
+impl SinkRef<[AudioFrame]> for WaveFileBufferSink {
     fn append(&mut self, buffer: &[(i16, i16)]) {
         for &(left, right) in buffer {
             self.write_u16(left as _).unwrap();
@@ -88,7 +88,4 @@ impl SinkRef<[(i16, i16)]> for WaveFileBufferSink {
             self.num_frames += 1;
         }
     }
-}
-
-impl AudioBufferSink for WaveFileBufferSink {
 }

--- a/rustual-boy-core/src/audio_buffer_sink.rs
+++ b/rustual-boy-core/src/audio_buffer_sink.rs
@@ -1,3 +1,0 @@
-pub trait AudioBufferSink {
-    fn append(&mut self, buffer: &[(i16, i16)]);
-}

--- a/rustual-boy-core/src/audio_frame_sink.rs
+++ b/rustual-boy-core/src/audio_frame_sink.rs
@@ -1,3 +1,0 @@
-pub trait AudioFrameSink {
-    fn append(&mut self, frame: (i16, i16));
-}

--- a/rustual-boy-core/src/interconnect.rs
+++ b/rustual-boy-core/src/interconnect.rs
@@ -1,5 +1,4 @@
-use video_frame_sink::*;
-use audio_frame_sink::*;
+use sinks::*;
 use rom::*;
 use wram::*;
 use sram::*;

--- a/rustual-boy-core/src/interconnect.rs
+++ b/rustual-boy-core/src/interconnect.rs
@@ -203,7 +203,7 @@ impl Interconnect {
         }
     }
 
-    pub fn cycles(&mut self, cycles: usize, video_frame_sink: &mut VideoFrameSink, audio_frame_sink: &mut AudioFrameSink) -> Option<u16> {
+    pub fn cycles(&mut self, cycles: usize, video_frame_sink: &mut Sink<VideoFrame>, audio_frame_sink: &mut Sink<AudioFrame>) -> Option<u16> {
         let mut interrupt = None;
 
         if self.timer.cycles(cycles) {

--- a/rustual-boy-core/src/lib.rs
+++ b/rustual-boy-core/src/lib.rs
@@ -4,17 +4,15 @@ extern crate encoding;
 mod logging;
 mod mem_map;
 
-pub mod audio_buffer_sink;
-pub mod audio_frame_sink;
 pub mod game_pad;
 pub mod instruction;
 pub mod interconnect;
 pub mod nvc;
 pub mod rom;
+pub mod sinks;
 pub mod sram;
 pub mod time_source;
 pub mod timer;
-pub mod video_frame_sink;
 pub mod vip;
 pub mod virtual_boy;
 pub mod vsu;

--- a/rustual-boy-core/src/sinks.rs
+++ b/rustual-boy-core/src/sinks.rs
@@ -9,17 +9,11 @@ pub trait SinkRef<T: ?Sized> {
     fn append(&mut self, value: &T);
 }
 
-/// A frame of video. The Boxs contain the left/right monochrome
+/// A frame of video. The `Box`es contain the left/right monochrome
 /// [DISPLAY_RESOLUTION_X](../vip/constant.DISPLAY_RESOLUTION_X.html) by
 /// [DISPLAY_RESOLUTION_Y](../vip/constant.DISPLAY_RESOLUTION_Y.html)
 /// pixels, after gamma mapping.
 pub type VideoFrame = (Box<[u8]>, Box<[u8]>);
 
-/// A sink for video frames.
-pub trait VideoFrameSink: Sink<VideoFrame> {}
-
-/// A sink for audio buffers
-pub trait AudioBufferSink: SinkRef<[(i16, i16)]> {}
-
-/// A sink for individual audio frames
-pub trait AudioFrameSink: Sink<(i16, i16)> {}
+/// A frame of audio (left, right).
+pub type AudioFrame = (i16, i16);

--- a/rustual-boy-core/src/sinks.rs
+++ b/rustual-boy-core/src/sinks.rs
@@ -12,7 +12,7 @@ pub trait SinkRef<T: ?Sized> {
 /// A frame of video. The `Box`es contain the left/right monochrome
 /// [DISPLAY_RESOLUTION_X](../vip/constant.DISPLAY_RESOLUTION_X.html) by
 /// [DISPLAY_RESOLUTION_Y](../vip/constant.DISPLAY_RESOLUTION_Y.html)
-/// pixels, after gamma mapping.
+/// pixels in linear brightness.
 pub type VideoFrame = (Box<[u8]>, Box<[u8]>);
 
 /// A frame of audio (left, right).

--- a/rustual-boy-core/src/sinks.rs
+++ b/rustual-boy-core/src/sinks.rs
@@ -1,0 +1,25 @@
+/// Represents a sink
+pub trait Sink<T> {
+    /// Push a value out the sink
+    fn append(&mut self, value: T);
+}
+
+/// Represents a sink of value references.
+pub trait SinkRef<T: ?Sized> {
+    fn append(&mut self, value: &T);
+}
+
+/// A frame of video. The Boxs contain the left/right monochrome
+/// [DISPLAY_RESOLUTION_X](../vip/constant.DISPLAY_RESOLUTION_X.html) by
+/// [DISPLAY_RESOLUTION_Y](../vip/constant.DISPLAY_RESOLUTION_Y.html)
+/// pixels, after gamma mapping.
+pub type VideoFrame = (Box<[u8]>, Box<[u8]>);
+
+/// A sink for video frames.
+pub trait VideoFrameSink: Sink<VideoFrame> {}
+
+/// A sink for audio buffers
+pub trait AudioBufferSink: SinkRef<[(i16, i16)]> {}
+
+/// A sink for individual audio frames
+pub trait AudioFrameSink: Sink<(i16, i16)> {}

--- a/rustual-boy-core/src/video_frame_sink.rs
+++ b/rustual-boy-core/src/video_frame_sink.rs
@@ -1,3 +1,0 @@
-pub trait VideoFrameSink {
-    fn append(&mut self, frame: (Box<[u8]>, Box<[u8]>));
-}

--- a/rustual-boy-core/src/vip/mod.rs
+++ b/rustual-boy-core/src/vip/mod.rs
@@ -1,6 +1,7 @@
 mod mem_map;
 
-use video_frame_sink::*;
+use sinks::VideoFrameSink;
+
 use self::mem_map::*;
 
 const FRAMEBUFFER_RESOLUTION_X: usize = 384;

--- a/rustual-boy-core/src/vip/mod.rs
+++ b/rustual-boy-core/src/vip/mod.rs
@@ -1,6 +1,6 @@
 mod mem_map;
 
-use sinks::VideoFrameSink;
+use sinks::*;
 
 use self::mem_map::*;
 
@@ -512,7 +512,7 @@ impl Vip {
         }
     }
 
-    pub fn cycles(&mut self, cycles: usize, video_frame_sink: &mut VideoFrameSink) -> bool {
+    pub fn cycles(&mut self, cycles: usize, video_frame_sink: &mut Sink<VideoFrame>) -> bool {
         let mut raise_interrupt = false;
 
         for _ in 0..cycles {
@@ -1103,7 +1103,7 @@ impl Vip {
         self.write_vram_byte(framebuffer_offset + framebuffer_byte_index, framebuffer_byte);
     }
 
-    fn display(&mut self, video_frame_sink: &mut VideoFrameSink) {
+    fn display(&mut self, video_frame_sink: &mut Sink<VideoFrame>) {
         let left_framebuffer_offset = if self.display_first_framebuffers { 0x00000000 } else { 0x00008000 };
         let right_framebuffer_offset = left_framebuffer_offset + 0x00010000;
 

--- a/rustual-boy-core/src/vip/mod.rs
+++ b/rustual-boy-core/src/vip/mod.rs
@@ -9,6 +9,7 @@ const FRAMEBUFFER_RESOLUTION_Y: usize = 256;
 
 pub const DISPLAY_RESOLUTION_X: usize = 384;
 pub const DISPLAY_RESOLUTION_Y: usize = 224;
+pub const DISPLAY_PIXELS: usize = DISPLAY_RESOLUTION_X * DISPLAY_RESOLUTION_Y;
 
 const DRAWING_BLOCK_HEIGHT: usize = 8;
 const DRAWING_BLOCK_COUNT: usize = DISPLAY_RESOLUTION_Y / DRAWING_BLOCK_HEIGHT;
@@ -117,28 +118,12 @@ pub struct Vip {
 
     display_first_framebuffers: bool,
     last_clear_color: u8,
-
-    gamma_table: Box<[u8; 256]>,
 }
 
 impl Vip {
     pub fn new() -> Vip {
         let mut vram = vec![0; VRAM_LENGTH as usize].into_boxed_slice();
         let vram_ptr = vram.as_mut_ptr();
-
-        let gamma = 2.2;
-        let mut gamma_table = Box::new([0; 256]);
-        for (i, entry) in gamma_table.iter_mut().enumerate() {
-            let mut value = (((i as f64) / 255.0).powf(1.0 / gamma) * 255.0) as isize;
-            if value < 0 {
-                value = 0;
-            }
-            if value > 255 {
-                value = 0;
-            }
-
-            *entry = value as u8;
-        }
 
         Vip {
             _vram: vram,
@@ -202,8 +187,6 @@ impl Vip {
 
             display_first_framebuffers: false,
             last_clear_color: 0,
-
-            gamma_table: gamma_table,
         }
     }
 
@@ -1107,27 +1090,24 @@ impl Vip {
         let left_framebuffer_offset = if self.display_first_framebuffers { 0x00000000 } else { 0x00008000 };
         let right_framebuffer_offset = left_framebuffer_offset + 0x00010000;
 
-        let mut left_buffer = vec![0; DISPLAY_RESOLUTION_X * DISPLAY_RESOLUTION_Y].into_boxed_slice();
-        let mut right_buffer = vec![0; DISPLAY_RESOLUTION_X * DISPLAY_RESOLUTION_Y].into_boxed_slice();
+        let mut left_buffer = vec![0; DISPLAY_PIXELS].into_boxed_slice();
+        let mut right_buffer = vec![0; DISPLAY_PIXELS].into_boxed_slice();
         let left_buffer_ptr = left_buffer.as_mut_ptr();
         let right_buffer_ptr = right_buffer.as_mut_ptr();
 
         if self.reg_display_control_display_enable && self.reg_display_control_sync_enable {
-            let mut brightness_1_index = (self.reg_led_brightness_1 as usize) * 2;
-            let mut brightness_2_index = (self.reg_led_brightness_2 as usize) * 2;
-            let mut brightness_3_index = ((self.reg_led_brightness_1 as usize) + (self.reg_led_brightness_2 as usize) + (self.reg_led_brightness_3 as usize)) * 2;
-            if brightness_1_index > 255 {
-                brightness_1_index = 255;
+            let mut brightness_1 = (self.reg_led_brightness_1 as usize) * 2;
+            let mut brightness_2 = (self.reg_led_brightness_2 as usize) * 2;
+            let mut brightness_3 = ((self.reg_led_brightness_1 as usize) + (self.reg_led_brightness_2 as usize) + (self.reg_led_brightness_3 as usize)) * 2;
+            if brightness_1 > 255 {
+                brightness_1 = 255;
             }
-            if brightness_2_index > 255 {
-                brightness_2_index = 255;
+            if brightness_2 > 255 {
+                brightness_2 = 255;
             }
-            if brightness_3_index > 255 {
-                brightness_3_index = 255;
+            if brightness_3 > 255 {
+                brightness_3 = 255;
             }
-            let brightness_1 = self.gamma_table[brightness_1_index] as u32;
-            let brightness_2 = self.gamma_table[brightness_2_index] as u32;
-            let brightness_3 = self.gamma_table[brightness_3_index] as u32;
 
             unsafe {
                 for pixel_x in 0..DISPLAY_RESOLUTION_X as u32 {

--- a/rustual-boy-core/src/virtual_boy.rs
+++ b/rustual-boy-core/src/virtual_boy.rs
@@ -17,7 +17,7 @@ impl VirtualBoy {
         }
     }
 
-    pub fn step(&mut self, video_frame_sink: &mut VideoFrameSink, audio_frame_sink: &mut AudioFrameSink) -> (usize, bool) {
+    pub fn step(&mut self, video_frame_sink: &mut Sink<VideoFrame>, audio_frame_sink: &mut Sink<AudioFrame>) -> (usize, bool) {
         let ret = self.cpu.step(&mut self.interconnect);
 
         if let Some(exception_code) = self.interconnect.cycles(ret.0, video_frame_sink, audio_frame_sink) {

--- a/rustual-boy-core/src/virtual_boy.rs
+++ b/rustual-boy-core/src/virtual_boy.rs
@@ -1,5 +1,4 @@
-use video_frame_sink::*;
-use audio_frame_sink::*;
+use sinks::*;
 use rom::*;
 use sram::*;
 use interconnect::*;

--- a/rustual-boy-core/src/vsu/mod.rs
+++ b/rustual-boy-core/src/vsu/mod.rs
@@ -1,6 +1,7 @@
 mod mem_map;
 
-use sinks::AudioFrameSink;
+use sinks::*;
+
 use self::mem_map::*;
 
 // Docs claim the sample rate is 41.7khz, but my calculations indicate it should be 41666.66hz repeating
@@ -626,7 +627,7 @@ impl Vsu {
         self.write_byte(addr, value as _);
     }
 
-    pub fn cycles(&mut self, num_cycles: usize, audio_frame_sink: &mut AudioFrameSink) {
+    pub fn cycles(&mut self, num_cycles: usize, audio_frame_sink: &mut Sink<AudioFrame>) {
         for _ in 0..num_cycles {
             self.duration_clock_counter += 1;
             if self.duration_clock_counter >= DURATION_CLOCK_PERIOD {
@@ -690,7 +691,7 @@ impl Vsu {
         }
     }
 
-    fn sample_clock(&mut self, audio_frame_sink: &mut AudioFrameSink) {
+    fn sample_clock(&mut self, audio_frame_sink: &mut Sink<AudioFrame>) {
         let mut acc_left = 0;
         let mut acc_right = 0;
 

--- a/rustual-boy-core/src/vsu/mod.rs
+++ b/rustual-boy-core/src/vsu/mod.rs
@@ -1,6 +1,6 @@
 mod mem_map;
 
-use audio_frame_sink::*;
+use sinks::AudioFrameSink;
 use self::mem_map::*;
 
 // Docs claim the sample rate is 41.7khz, but my calculations indicate it should be 41666.66hz repeating

--- a/rustual-boy-middleware/Cargo.lock
+++ b/rustual-boy-middleware/Cargo.lock
@@ -1,0 +1,79 @@
+[root]
+name = "rustual-boy-middleware"
+version = "0.1.0"
+dependencies = [
+ "rustual-boy-core 0.1.0",
+]
+
+[[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustual-boy-core"
+version = "0.1.0"
+dependencies = [
+ "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+"checksum encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+"checksum encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+"checksum encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+"checksum encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+"checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+"checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"

--- a/rustual-boy-middleware/Cargo.toml
+++ b/rustual-boy-middleware/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rustual-boy-middleware"
+version = "0.1.0"
+authors = ["bobtwinkles <srkoser+github@gmail.com>"]
+
+[dependencies]
+rustual-boy-core = { path = "../rustual-boy-core" }

--- a/rustual-boy-middleware/Cargo.toml
+++ b/rustual-boy-middleware/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "rustual-boy-middleware"
 version = "0.1.0"
-authors = ["bobtwinkles <srkoser+github@gmail.com>"]
+authors = ["ferris <yupferris@gmail.com>", "The Rustual Boy contributors"]
+description = "Some useful utilities for implementing Rustual Boy frontends"
+readme = "README.md"
+license = "MIT/Apache-2.0"
+repository = "https://github.com/emu-rs/rustual-boy"
+homepage = "https://github.com/emu-rs/rustual-boy"
 
 [dependencies]
 rustual-boy-core = { path = "../rustual-boy-core" }

--- a/rustual-boy-middleware/src/anaglyphizer.rs
+++ b/rustual-boy-middleware/src/anaglyphizer.rs
@@ -1,5 +1,5 @@
 use color::Color;
-use rustual_boy_core::sinks::{Sink, VideoFrame, VideoFrameSink};
+use rustual_boy_core::sinks::{Sink, VideoFrame};
 use rustual_boy_core::vip::{DISPLAY_RESOLUTION_X, DISPLAY_RESOLUTION_Y};
 
 const DISPLAY_PIXELS: usize = DISPLAY_RESOLUTION_X * DISPLAY_RESOLUTION_Y;
@@ -60,5 +60,3 @@ impl<T: Sink<ColorFrame>> Sink<VideoFrame> for Anaglyphizer<T> {
         self.inner.append(output.into_boxed_slice());
     }
 }
-
-impl<T: Sink<ColorFrame>> VideoFrameSink for Anaglyphizer<T> {}

--- a/rustual-boy-middleware/src/anaglyphizer.rs
+++ b/rustual-boy-middleware/src/anaglyphizer.rs
@@ -1,11 +1,7 @@
 use color::Color;
+use color_frame::ColorFrame;
 use rustual_boy_core::sinks::{Sink, VideoFrame};
-use rustual_boy_core::vip::{DISPLAY_RESOLUTION_X, DISPLAY_RESOLUTION_Y};
-
-const DISPLAY_PIXELS: usize = DISPLAY_RESOLUTION_X * DISPLAY_RESOLUTION_Y;
-
-/// Frame of color imagery
-pub type ColorFrame = Box<[Color]>;
+use rustual_boy_core::vip::DISPLAY_PIXELS;
 
 /// A utility for the Rustual Boy core that collapses the left/right
 /// anaglyph channels in to a single buffer.

--- a/rustual-boy-middleware/src/anaglyphizer.rs
+++ b/rustual-boy-middleware/src/anaglyphizer.rs
@@ -52,7 +52,7 @@ impl<T: Sink<ColorFrame>> Sink<VideoFrame> for Anaglyphizer<T> {
                     let l = self.left_color.scale_by(l);
                     let r = self.right_color.scale_by(r);
 
-                    *o_ptr.offset(i) = l.add_color(r);
+                    *o_ptr.offset(i) = l + r;
                 }
             }
             output.set_len(DISPLAY_PIXELS);

--- a/rustual-boy-middleware/src/anaglyphizer.rs
+++ b/rustual-boy-middleware/src/anaglyphizer.rs
@@ -1,50 +1,64 @@
 use color::Color;
-use rustual_boy_core::sinks::{VideoFrame};
+use rustual_boy_core::sinks::{Sink, VideoFrame, VideoFrameSink};
 use rustual_boy_core::vip::{DISPLAY_RESOLUTION_X, DISPLAY_RESOLUTION_Y};
 
 const DISPLAY_PIXELS: usize = DISPLAY_RESOLUTION_X * DISPLAY_RESOLUTION_Y;
 
+/// Frame of color imagery
+pub type ColorFrame = Box<[Color]>;
+
 /// A utility for the Rustual Boy core that collapses the left/right
 /// anaglyph channels in to a single buffer.
-pub struct Anaglyphizer {
+pub struct Anaglyphizer<T: Sink<ColorFrame>> {
     /// Color of the left channel
     left_color: Color,
     /// Color of the right channel
     right_color: Color,
+    /// Sink to which we push our frame as they come in
+    inner: T
 }
 
-impl Anaglyphizer {
+impl<T: Sink<ColorFrame>> Anaglyphizer<T> {
     /// Create a new Anaglyphizer which will use the provided colors for
     /// the left and right channels
-    pub fn new(left_color: Color, right_color: Color) -> Anaglyphizer {
+    pub fn new(inner: T, left_color: Color, right_color: Color) -> Anaglyphizer<T> {
         Anaglyphizer {
             left_color: left_color,
             right_color: right_color,
+            inner: inner,
         }
     }
 
-    /// Compute the final anaglyph image, using the provided VideoFrame.
-    pub fn collapse_into(&self, frame: VideoFrame, output: &mut [u32]) {
-        if output.len() < DISPLAY_PIXELS {
-            panic!("Display output buffer not large enough");
-        }
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T: Sink<ColorFrame>> Sink<VideoFrame> for Anaglyphizer<T> {
+    fn append(&mut self, frame: VideoFrame) {
+        let mut output = Vec::new();
+        output.reserve_exact(DISPLAY_PIXELS);
         let (ref l_buffer, ref r_buffer) = frame;
 
         unsafe {
             let l_buffer = l_buffer.as_ptr();
             let r_buffer = r_buffer.as_ptr();
-            let o_ptr = output.as_mut_ptr();
-            for i in 0..(DISPLAY_PIXELS as isize) {
-                let l = *(l_buffer.offset(i));
-                let r = *(r_buffer.offset(i));
+            {
+                let o_ptr = output.as_mut_ptr();
+                for i in 0..(DISPLAY_PIXELS as isize) {
+                    let l = *(l_buffer.offset(i));
+                    let r = *(r_buffer.offset(i));
 
-                let l = self.left_color.scale_by(l);
-                let r = self.right_color.scale_by(r);
+                    let l = self.left_color.scale_by(l);
+                    let r = self.right_color.scale_by(r);
 
-                let c = l.add_color(r);
-
-                *o_ptr.offset(i) = c.into();
+                    *o_ptr.offset(i) = l.add_color(r);
+                }
             }
+            output.set_len(DISPLAY_PIXELS);
         }
+        self.inner.append(output.into_boxed_slice());
     }
 }
+
+impl<T: Sink<ColorFrame>> VideoFrameSink for Anaglyphizer<T> {}

--- a/rustual-boy-middleware/src/color.rs
+++ b/rustual-boy-middleware/src/color.rs
@@ -1,4 +1,5 @@
-//! Some color utilities that are useful for implementing the anaglyph modes
+//! Some color utilities that are useful for implementing color transforms,
+//! anaglyph modes, etc.
 
 use std::ops::Add;
 
@@ -10,7 +11,7 @@ pub struct Color {
 }
 
 impl From<(f32, f32, f32)> for Color {
-    /// Convert a tuple of RGB in the [0, 1] range to a color
+    /// Convert a tuple of RGB in the [0, 1] range into a color
     fn from((r, g, b): (f32, f32, f32)) -> Color {
         let r = (r * 255.0) as u8;
         let g = (g * 255.0) as u8;
@@ -20,7 +21,7 @@ impl From<(f32, f32, f32)> for Color {
 }
 
 impl From<u32> for Color {
-    /// Convert a packed integer in to a color, where the compnents are RGB
+    /// Convert a packed integer into a color, where the compnents are RGB
     /// from most significant to least significant byte
     fn from(i: u32) -> Color {
         let r = ((i >> 16) & 0xFF) as u8;
@@ -32,7 +33,8 @@ impl From<u32> for Color {
 }
 
 impl Into<u32> for Color {
-    /// Convert a color from a float tuple in to RGB packed format
+    /// Convert a color into RGB packed format, where the compnents are RGB
+    /// from most significant to least significant byte
     fn into(self) -> u32 {
         let r = self.r as u32;
         let g = self.g as u32;
@@ -43,6 +45,7 @@ impl Into<u32> for Color {
 }
 
 impl<'a> Into<u32> for &'a Color {
+    /// Convert a color reference into RGB packed format
     fn into(self) -> u32 {
         let r = self.r as u32;
         let g = self.g as u32;
@@ -53,9 +56,23 @@ impl<'a> Into<u32> for &'a Color {
 }
 
 impl From<(u8, u8, u8)> for Color {
-    /// Convert a tuple of u8s to a color
+    /// Convert a tuple of u8's (R, G, B) into a color
     fn from((r, g, b): (u8, u8, u8)) -> Color {
         Color { r: r, g: g, b: b }
+    }
+}
+
+impl Into<(u8, u8, u8)> for Color {
+    /// Convert a color into a tuple of u8's (R, G, B)
+    fn into(self) -> (u8, u8, u8) {
+        (self.r, self.g, self.b)
+    }
+}
+
+impl<'a> Into<(u8, u8, u8)> for &'a Color {
+    /// Convert a color into a tuple of u8's (R, G, B)
+    fn into(self) -> (u8, u8, u8) {
+        (self.r, self.g, self.b)
     }
 }
 

--- a/rustual-boy-middleware/src/color.rs
+++ b/rustual-boy-middleware/src/color.rs
@@ -1,0 +1,69 @@
+//! Some color utilities that are useful for implementing the anaglyph modes
+
+/// Represents a color
+pub struct Color {
+    r: f32,
+    g: f32,
+    b: f32,
+}
+
+impl From<(f32, f32, f32)> for Color {
+    /// Convert a tuple of RGB in the [0, 1] range to a color
+    fn from((r, g, b): (f32, f32, f32)) -> Color {
+        Color {r: r, g: g, b: b}
+    }
+}
+
+impl From<u32> for Color {
+    /// Convert a packed integer in to a color, where the compnents are RGB
+    /// from most significant to least significant byte
+    fn from(i: u32) -> Color {
+        let r = (((i >> 16) & 0xFF) as u32) as f32;
+        let g = (((i >> 8) & 0xFF) as u32) as f32;
+        let b = ((i & 0xFF) as u32) as f32;
+
+        Color {r: r, g: g, b: b}
+    }
+}
+
+impl Into<u32> for Color {
+    /// Convert a color from a float tuple in to RGB packed format
+    fn into(self) -> u32 {
+        let r = (self.r * 255.0) as u32;
+        let g = (self.g * 255.0) as u32;
+        let b = (self.b * 255.0) as u32;
+
+        (r << 16) | (g << 8) | b
+    }
+}
+
+impl From<(u8, u8, u8)> for Color {
+    /// Convert a tuple of u8s to a color
+    fn from((r, g, b): (u8, u8, u8)) -> Color {
+        let r = (r as f32) / 255.0;
+        let g = (g as f32) / 255.0;
+        let b = (b as f32) / 255.0;
+
+        Color {r: r, g: g, b: b}
+    }
+}
+
+impl Color {
+    /// Compute the sum of two colors
+    pub fn add_color(&self, col: Color) -> Color {
+        Color {
+            r: self.r + col.r,
+            g: self.g + col.g,
+            b: self.b + col.b
+        }
+    }
+
+    /// Scale a color by a uniform constant factor
+    pub fn scale_color(&self, s: f32) -> Color {
+        Color {
+            r: s * self.r,
+            g: s * self.g,
+            b: s * self.b,
+        }
+    }
+}

--- a/rustual-boy-middleware/src/color.rs
+++ b/rustual-boy-middleware/src/color.rs
@@ -40,6 +40,16 @@ impl Into<u32> for Color {
     }
 }
 
+impl<'a> Into<u32> for &'a Color {
+    fn into(self) -> u32 {
+        let r = self.r as u32;
+        let g = self.g as u32;
+        let b = self.b as u32;
+
+        (r << 16) | (g << 8) | b
+    }
+}
+
 impl From<(u8, u8, u8)> for Color {
     /// Convert a tuple of u8s to a color
     fn from((r, g, b): (u8, u8, u8)) -> Color {

--- a/rustual-boy-middleware/src/color.rs
+++ b/rustual-boy-middleware/src/color.rs
@@ -1,5 +1,7 @@
 //! Some color utilities that are useful for implementing the anaglyph modes
 
+use std::ops::Add;
+
 /// Represents a color
 pub struct Color {
     r: u8,
@@ -58,15 +60,6 @@ impl From<(u8, u8, u8)> for Color {
 }
 
 impl Color {
-    /// Compute the sum of two colors
-    pub fn add_color(&self, col: Color) -> Color {
-        Color {
-            r: self.r.saturating_add(col.r),
-            g: self.g.saturating_add(col.g),
-            b: self.b.saturating_add(col.b)
-        }
-    }
-
     /// Scale a color by a uniform constant factor
     pub fn scale_by(&self, u: u8) -> Color {
         let s = u as u32;
@@ -77,6 +70,18 @@ impl Color {
             r: (s * r / 255) as u8,
             g: (s * g / 255) as u8,
             b: (s * b / 255) as u8,
+        }
+    }
+}
+
+impl Add for Color {
+    type Output = Color;
+
+    fn add(self, other: Color) -> Color {
+        Color {
+            r: self.r.saturating_add(other.r),
+            g: self.g.saturating_add(other.g),
+            b: self.b.saturating_add(other.b),
         }
     }
 }

--- a/rustual-boy-middleware/src/color.rs
+++ b/rustual-boy-middleware/src/color.rs
@@ -2,15 +2,18 @@
 
 /// Represents a color
 pub struct Color {
-    r: f32,
-    g: f32,
-    b: f32,
+    r: u8,
+    g: u8,
+    b: u8,
 }
 
 impl From<(f32, f32, f32)> for Color {
     /// Convert a tuple of RGB in the [0, 1] range to a color
     fn from((r, g, b): (f32, f32, f32)) -> Color {
-        Color {r: r, g: g, b: b}
+        let r = (r * 255.0) as u8;
+        let g = (g * 255.0) as u8;
+        let b = (b * 255.0) as u8;
+        Color { r: r, g: g, b: b }
     }
 }
 
@@ -18,20 +21,20 @@ impl From<u32> for Color {
     /// Convert a packed integer in to a color, where the compnents are RGB
     /// from most significant to least significant byte
     fn from(i: u32) -> Color {
-        let r = (((i >> 16) & 0xFF) as u32) as f32;
-        let g = (((i >> 8) & 0xFF) as u32) as f32;
-        let b = ((i & 0xFF) as u32) as f32;
+        let r = ((i >> 16) & 0xFF) as u8;
+        let g = ((i >> 8) & 0xFF) as u8;
+        let b = (i & 0xFF) as u8;
 
-        Color {r: r, g: g, b: b}
+        Color { r: r, g: g, b: b }
     }
 }
 
 impl Into<u32> for Color {
     /// Convert a color from a float tuple in to RGB packed format
     fn into(self) -> u32 {
-        let r = (self.r * 255.0) as u32;
-        let g = (self.g * 255.0) as u32;
-        let b = (self.b * 255.0) as u32;
+        let r = self.r as u32;
+        let g = self.g as u32;
+        let b = self.b as u32;
 
         (r << 16) | (g << 8) | b
     }
@@ -40,11 +43,7 @@ impl Into<u32> for Color {
 impl From<(u8, u8, u8)> for Color {
     /// Convert a tuple of u8s to a color
     fn from((r, g, b): (u8, u8, u8)) -> Color {
-        let r = (r as f32) / 255.0;
-        let g = (g as f32) / 255.0;
-        let b = (b as f32) / 255.0;
-
-        Color {r: r, g: g, b: b}
+        Color { r: r, g: g, b: b }
     }
 }
 
@@ -52,18 +51,22 @@ impl Color {
     /// Compute the sum of two colors
     pub fn add_color(&self, col: Color) -> Color {
         Color {
-            r: self.r + col.r,
-            g: self.g + col.g,
-            b: self.b + col.b
+            r: self.r.saturating_add(col.r),
+            g: self.g.saturating_add(col.g),
+            b: self.b.saturating_add(col.b)
         }
     }
 
     /// Scale a color by a uniform constant factor
-    pub fn scale_color(&self, s: f32) -> Color {
+    pub fn scale_by(&self, u: u8) -> Color {
+        let s = u as u32;
+        let r = self.r as u32;
+        let g = self.g as u32;
+        let b = self.b as u32;
         Color {
-            r: s * self.r,
-            g: s * self.g,
-            b: s * self.b,
+            r: (s * r / 255) as u8,
+            g: (s * g / 255) as u8,
+            b: (s * b / 255) as u8,
         }
     }
 }

--- a/rustual-boy-middleware/src/color_frame.rs
+++ b/rustual-boy-middleware/src/color_frame.rs
@@ -1,0 +1,4 @@
+use color::Color;
+
+/// Frame of color imagery
+pub type ColorFrame = Box<[Color]>;

--- a/rustual-boy-middleware/src/frame_sink.rs
+++ b/rustual-boy-middleware/src/frame_sink.rs
@@ -1,12 +1,12 @@
 use rustual_boy_core::sinks::{Sink, VideoFrame, VideoFrameSink};
 
-/// A frame sink that keeps track of only the most recent frame
-pub struct MostRecentFrameSink {
-    inner: Option<VideoFrame>
+/// A sink that keeps track of only the most recent
+pub struct MostRecentFrameSink<T> {
+    inner: Option<T>
 }
 
-impl MostRecentFrameSink {
-    pub fn new() -> MostRecentFrameSink {
+impl<T> MostRecentFrameSink<T> {
+    pub fn new() -> MostRecentFrameSink<T> {
         MostRecentFrameSink { inner: None }
     }
 
@@ -16,12 +16,12 @@ impl MostRecentFrameSink {
     }
 
     /// Convert ourself in to a frame
-    pub fn into_frame(self) -> Option<VideoFrame> {
+    pub fn into_frame(self) -> Option<T> {
         self.inner
     }
 }
 
-impl Sink<VideoFrame> for MostRecentFrameSink {
+impl<T> Sink<T> for MostRecentFrameSink<T> {
     fn append(&mut self, frame: VideoFrame) {
         self.inner = Some(frame);
     }

--- a/rustual-boy-middleware/src/frame_sink.rs
+++ b/rustual-boy-middleware/src/frame_sink.rs
@@ -1,0 +1,30 @@
+use rustual_boy_core::sinks::{Sink, VideoFrame, VideoFrameSink};
+
+/// A frame sink that keeps track of only the most recent frame
+pub struct MostRecentFrameSink {
+    inner: Option<VideoFrame>
+}
+
+impl MostRecentFrameSink {
+    pub fn new() -> MostRecentFrameSink {
+        MostRecentFrameSink { inner: None }
+    }
+
+    /// Returns true when we have a frame available
+    pub fn has_frame(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    /// Convert ourself in to a frame
+    pub fn into_frame(self) -> Option<VideoFrame> {
+        self.inner
+    }
+}
+
+impl Sink<VideoFrame> for MostRecentFrameSink {
+    fn append(&mut self, frame: VideoFrame) {
+        self.inner = Some(frame);
+    }
+}
+
+impl VideoFrameSink for MostRecentFrameSink {}

--- a/rustual-boy-middleware/src/frame_sink.rs
+++ b/rustual-boy-middleware/src/frame_sink.rs
@@ -1,4 +1,4 @@
-use rustual_boy_core::sinks::{Sink, VideoFrame, VideoFrameSink};
+use rustual_boy_core::sinks::{Sink, VideoFrame};
 
 /// A sink that keeps track of only the most recent
 pub struct MostRecentFrameSink<T> {
@@ -26,5 +26,3 @@ impl<T> Sink<T> for MostRecentFrameSink<T> {
         self.inner = Some(frame);
     }
 }
-
-impl VideoFrameSink for MostRecentFrameSink {}

--- a/rustual-boy-middleware/src/gamma_adjust_sink.rs
+++ b/rustual-boy-middleware/src/gamma_adjust_sink.rs
@@ -1,0 +1,66 @@
+use color_frame::ColorFrame;
+use rustual_boy_core::sinks::Sink;
+use rustual_boy_core::vip::DISPLAY_PIXELS;
+
+/// A utility for adjusting a ColorFrame's gamma curve.
+/// Typically used with a gamma of 2.2 to prepare a linear
+/// buffer for sRGB pixel output.
+pub struct GammaAdjustSink<T: Sink<ColorFrame>> {
+    inner: T,
+    gamma_table: Box<[u8; 256]>,
+}
+
+impl<T: Sink<ColorFrame>> GammaAdjustSink<T> {
+    /// Create a new GammaAdjustSink which will use the provided gamma
+    /// value for adjustment (typically 2.2 for basic RGB -> sRGB
+    /// conversion).
+    pub fn new(inner: T, gamma: f64) -> GammaAdjustSink<T> {
+        let mut gamma_table = Box::new([0; 256]);
+        for (i, entry) in gamma_table.iter_mut().enumerate() {
+            let mut value = (((i as f64) / 255.0).powf(1.0 / gamma) * 255.0) as isize;
+            if value < 0 {
+                value = 0;
+            }
+            if value > 255 {
+                value = 0;
+            }
+
+            *entry = value as u8;
+        }
+
+        GammaAdjustSink {
+            inner: inner,
+            gamma_table: gamma_table,
+        }
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T: Sink<ColorFrame>> Sink<ColorFrame> for GammaAdjustSink<T> {
+    fn append(&mut self, frame: ColorFrame) {
+        let mut output = Vec::new();
+        output.reserve_exact(DISPLAY_PIXELS);
+
+        unsafe {
+            let input_buffer_ptr = frame.as_ptr();
+            {
+                let output_buffer_ptr = output.as_mut_ptr();
+                for i in 0..(DISPLAY_PIXELS as isize) {
+                    let ref input = *(input_buffer_ptr.offset(i));
+                    let (input_r, input_g, input_b) = input.into();
+
+                    let output_r = self.gamma_table[input_r as usize];
+                    let output_g = self.gamma_table[input_g as usize];
+                    let output_b = self.gamma_table[input_b as usize];
+
+                    *output_buffer_ptr.offset(i) = (output_r, output_g, output_b).into();
+                }
+            }
+            output.set_len(DISPLAY_PIXELS);
+        }
+        self.inner.append(output.into_boxed_slice());
+    }
+}

--- a/rustual-boy-middleware/src/lib.rs
+++ b/rustual-boy-middleware/src/lib.rs
@@ -3,7 +3,7 @@ extern crate rustual_boy_core;
 mod color;
 mod anaglyphizer;
 
-pub mod frame_sink;
+pub mod sinks;
 
 // reexports
 pub use color::Color;

--- a/rustual-boy-middleware/src/lib.rs
+++ b/rustual-boy-middleware/src/lib.rs
@@ -1,10 +1,13 @@
 extern crate rustual_boy_core;
 
 mod color;
+mod color_frame;
 mod anaglyphizer;
-
-pub mod sinks;
+mod gamma_adjust_sink;
+mod most_recent_sink;
 
 // reexports
 pub use color::Color;
 pub use anaglyphizer::Anaglyphizer;
+pub use gamma_adjust_sink::GammaAdjustSink;
+pub use most_recent_sink::MostRecentSink;

--- a/rustual-boy-middleware/src/lib.rs
+++ b/rustual-boy-middleware/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate rustual_boy_core;
 
-mod color;
+pub mod color;
 
 pub use color::Color;
 
@@ -56,14 +56,11 @@ impl AnaglyphFrameSink {
             let r_buffer = r_buffer.as_ptr();
             let o_ptr = output.as_mut_ptr();
             for i in 0..(DISPLAY_PIXELS as isize) {
-                let l = *(l_buffer.offset(i)) as u32;
-                let r = *(r_buffer.offset(i)) as u32;
+                let l = *(l_buffer.offset(i));
+                let r = *(r_buffer.offset(i));
 
-                let l = (l as f32) / 255.0;
-                let r = (r as f32) / 255.0;
-
-                let l = self.left_color.scale_color(l);
-                let r = self.right_color.scale_color(r);
+                let l = self.left_color.scale_by(l);
+                let r = self.right_color.scale_by(r);
 
                 let c = l.add_color(r);
 

--- a/rustual-boy-middleware/src/lib.rs
+++ b/rustual-boy-middleware/src/lib.rs
@@ -1,82 +1,10 @@
 extern crate rustual_boy_core;
 
-pub mod color;
+mod color;
+mod anaglyphizer;
 
+pub mod frame_sink;
+
+// reexports
 pub use color::Color;
-
-use rustual_boy_core::sinks::{Sink, VideoFrame, VideoFrameSink};
-use rustual_boy_core::vip::{DISPLAY_RESOLUTION_X, DISPLAY_RESOLUTION_Y};
-
-const DISPLAY_PIXELS: usize = DISPLAY_RESOLUTION_X * DISPLAY_RESOLUTION_Y;
-
-/// A VideoFrameSink for the Rustual Boy core that collapses the left/right
-/// anaglyph channels in to a single buffer.
-pub struct AnaglyphFrameSink {
-    /// Color of the left channel
-    left_color: Color,
-    /// Color of the right channel
-    right_color: Color,
-
-    inner: Option<VideoFrame>,
-}
-
-impl AnaglyphFrameSink {
-    /// Create a new AnaglyphFrameSink which will use the provided colors for
-    /// the left and right channels
-    pub fn new(left_color: Color, right_color: Color) -> AnaglyphFrameSink {
-        AnaglyphFrameSink {
-            left_color: left_color,
-            right_color: right_color,
-            inner: None
-        }
-    }
-
-    pub fn update_availible(&self) -> bool {
-        self.inner.is_some()
-    }
-
-    /// Compute the final anaglyph image, using the most recent frame and
-    /// dumping the output in to the provided buffer. If there is no data
-    /// availible in the frame buffer, the output argument is untouched
-    /// Returns true if a frame update was performed
-    pub fn update_output_buffer(&self, output: &mut [u32]) -> bool {
-        if output.len() < DISPLAY_PIXELS {
-            panic!("Display output buffer not large enough");
-        }
-        let &(ref l_buffer, ref r_buffer) = match self.inner {
-            Some(ref b) => b,
-            None => {
-                // Nothing to do, since we don't have any data
-                return false;
-            }
-        };
-
-        unsafe {
-            let l_buffer = l_buffer.as_ptr();
-            let r_buffer = r_buffer.as_ptr();
-            let o_ptr = output.as_mut_ptr();
-            for i in 0..(DISPLAY_PIXELS as isize) {
-                let l = *(l_buffer.offset(i));
-                let r = *(r_buffer.offset(i));
-
-                let l = self.left_color.scale_by(l);
-                let r = self.right_color.scale_by(r);
-
-                let c = l.add_color(r);
-
-                *o_ptr.offset(i) = c.into();
-            }
-        }
-
-        true
-    }
-}
-
-impl Sink<VideoFrame> for AnaglyphFrameSink {
-    fn append(&mut self, frame: VideoFrame) {
-        self.inner = Some(frame);
-    }
-}
-
-impl VideoFrameSink for AnaglyphFrameSink {
-}
+pub use anaglyphizer::Anaglyphizer;

--- a/rustual-boy-middleware/src/lib.rs
+++ b/rustual-boy-middleware/src/lib.rs
@@ -4,7 +4,7 @@ pub mod color;
 
 pub use color::Color;
 
-use rustual_boy_core::video_frame_sink::VideoFrameSink;
+use rustual_boy_core::sinks::{Sink, VideoFrame, VideoFrameSink};
 use rustual_boy_core::vip::{DISPLAY_RESOLUTION_X, DISPLAY_RESOLUTION_Y};
 
 const DISPLAY_PIXELS: usize = DISPLAY_RESOLUTION_X * DISPLAY_RESOLUTION_Y;
@@ -17,7 +17,7 @@ pub struct AnaglyphFrameSink {
     /// Color of the right channel
     right_color: Color,
 
-    inner: Option<(Box<[u8]>, Box<[u8]>)>,
+    inner: Option<VideoFrame>,
 }
 
 impl AnaglyphFrameSink {
@@ -72,8 +72,11 @@ impl AnaglyphFrameSink {
     }
 }
 
-impl VideoFrameSink for AnaglyphFrameSink {
-    fn append(&mut self, frame: (Box<[u8]>, Box<[u8]>)) {
+impl Sink<VideoFrame> for AnaglyphFrameSink {
+    fn append(&mut self, frame: VideoFrame) {
         self.inner = Some(frame);
     }
+}
+
+impl VideoFrameSink for AnaglyphFrameSink {
 }

--- a/rustual-boy-middleware/src/lib.rs
+++ b/rustual-boy-middleware/src/lib.rs
@@ -1,0 +1,82 @@
+extern crate rustual_boy_core;
+
+mod color;
+
+pub use color::Color;
+
+use rustual_boy_core::video_frame_sink::VideoFrameSink;
+use rustual_boy_core::vip::{DISPLAY_RESOLUTION_X, DISPLAY_RESOLUTION_Y};
+
+const DISPLAY_PIXELS: usize = DISPLAY_RESOLUTION_X * DISPLAY_RESOLUTION_Y;
+
+/// A VideoFrameSink for the Rustual Boy core that collapses the left/right
+/// anaglyph channels in to a single buffer.
+pub struct AnaglyphFrameSink {
+    /// Color of the left channel
+    left_color: Color,
+    /// Color of the right channel
+    right_color: Color,
+
+    inner: Option<(Box<[u8]>, Box<[u8]>)>,
+}
+
+impl AnaglyphFrameSink {
+    /// Create a new AnaglyphFrameSink which will use the provided colors for
+    /// the left and right channels
+    pub fn new(left_color: Color, right_color: Color) -> AnaglyphFrameSink {
+        AnaglyphFrameSink {
+            left_color: left_color,
+            right_color: right_color,
+            inner: None
+        }
+    }
+
+    pub fn update_availible(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    /// Compute the final anaglyph image, using the most recent frame and
+    /// dumping the output in to the provided buffer. If there is no data
+    /// availible in the frame buffer, the output argument is untouched
+    /// Returns true if a frame update was performed
+    pub fn update_output_buffer(&self, output: &mut [u32]) -> bool {
+        if output.len() < DISPLAY_PIXELS {
+            panic!("Display output buffer not large enough");
+        }
+        let &(ref l_buffer, ref r_buffer) = match self.inner {
+            Some(ref b) => b,
+            None => {
+                // Nothing to do, since we don't have any data
+                return false;
+            }
+        };
+
+        unsafe {
+            let l_buffer = l_buffer.as_ptr();
+            let r_buffer = r_buffer.as_ptr();
+            let o_ptr = output.as_mut_ptr();
+            for i in 0..(DISPLAY_PIXELS as isize) {
+                let l = *(l_buffer.offset(i)) as u32;
+                let r = *(r_buffer.offset(i)) as u32;
+
+                let l = (l as f32) / 255.0;
+                let r = (r as f32) / 255.0;
+
+                let l = self.left_color.scale_color(l);
+                let r = self.right_color.scale_color(r);
+
+                let c = l.add_color(r);
+
+                *o_ptr.offset(i) = c.into();
+            }
+        }
+
+        true
+    }
+}
+
+impl VideoFrameSink for AnaglyphFrameSink {
+    fn append(&mut self, frame: (Box<[u8]>, Box<[u8]>)) {
+        self.inner = Some(frame);
+    }
+}

--- a/rustual-boy-middleware/src/most_recent_sink.rs
+++ b/rustual-boy-middleware/src/most_recent_sink.rs
@@ -1,4 +1,4 @@
-use rustual_boy_core::sinks::{Sink, VideoFrame};
+use rustual_boy_core::sinks::Sink;
 
 /// A sink that keeps track of only the most recent value
 pub struct MostRecentSink<T> {

--- a/rustual-boy-middleware/src/sinks.rs
+++ b/rustual-boy-middleware/src/sinks.rs
@@ -1,4 +1,4 @@
-use rustual_boy_core::sinks::{Sink, VideoFrame, VideoFrameSink};
+use rustual_boy_core::sinks::{Sink, VideoFrame};
 
 /// A sink that keeps track of only the most recent value
 pub struct MostRecentSink<T> {
@@ -26,5 +26,3 @@ impl<T> Sink<T> for MostRecentSink<T> {
         self.inner = Some(v);
     }
 }
-
-impl VideoFrameSink for MostRecentSink<VideoFrame> {}

--- a/rustual-boy-middleware/src/sinks.rs
+++ b/rustual-boy-middleware/src/sinks.rs
@@ -1,0 +1,30 @@
+use rustual_boy_core::sinks::{Sink, VideoFrame, VideoFrameSink};
+
+/// A sink that keeps track of only the most recent value
+pub struct MostRecentSink<T> {
+    inner: Option<T>
+}
+
+impl<T> MostRecentSink<T> {
+    pub fn new() -> MostRecentSink<T> {
+        MostRecentSink { inner: None }
+    }
+
+    /// Returns true when we have a frame available
+    pub fn has_frame(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    /// Convert ourself in to a frame
+    pub fn into_inner(self) -> Option<T> {
+        self.inner
+    }
+}
+
+impl<T> Sink<T> for MostRecentSink<T> {
+    fn append(&mut self, v: T) {
+        self.inner = Some(v);
+    }
+}
+
+impl VideoFrameSink for MostRecentSink<VideoFrame> {}


### PR DESCRIPTION
PR to support common mode anaglyph rendering through an intermediate crate (`rustual-boy-middleware`). Marked as WIP because I'd like I'd like feedback on the anaglyph implementation;
  - The mixing stage is pretty expensive right now (lots of casting to floats and doing math and back to integers) and can probably be "cuter" but it'll probably be less clear. It seems fast enough for now, but I haven't run any numbers to see if that's sustainable
  - I'm also not confident that the color mixing is correct because color spaces bend my brain a bit. Additive is probably good enough but I think to be technically correct we should be converting from the response curve of the VB LEDs -> linear, performing the addition, and then converting from linear to sRGB.
  - Not sure how I feel about rolling our own color type. I'm not really sure where we would pull it from without adding a bunch of unnecessary dependencies though.