### PR TITLE
Use `size.is_power_of_two()` where appropriate

### DIFF
--- a/rustual-boy-core/src/rom.rs
+++ b/rustual-boy-core/src/rom.rs
@@ -23,7 +23,7 @@ impl Rom {
         file.read_to_end(&mut vec)?;
 
         let size = vec.len();
-        if size < MIN_ROM_SIZE || size > MAX_ROM_SIZE || size.count_ones() != 1 {
+        if size < MIN_ROM_SIZE || size > MAX_ROM_SIZE || !size.is_power_of_two() {
             return Err(Error::new(ErrorKind::InvalidData, "Invalid ROM size"));
         }
 

--- a/rustual-boy-core/src/sram.rs
+++ b/rustual-boy-core/src/sram.rs
@@ -31,7 +31,7 @@ impl Sram {
         file.read_to_end(&mut vec)?;
 
         let size = vec.len();
-        if size < MIN_SRAM_SIZE || size > MAX_SRAM_SIZE || size.count_ones() != 1 {
+        if size < MIN_SRAM_SIZE || size > MAX_SRAM_SIZE || !size.is_power_of_two() {
             return Err(Error::new(ErrorKind::InvalidData, "Invalid SRAM size"));
         }
 


### PR DESCRIPTION
Checking if there is only one set bit in an integer is just checking for powers of two, and there's a helper function specifically for that.