### PR TITLE
Add the ability to enable/disable logging of each subsystem in the core

### DIFF
--- a/rustual-boy-cli/Cargo.toml
+++ b/rustual-boy-cli/Cargo.toml
@@ -9,7 +9,14 @@ repository = "https://github.com/emu-rs/rustual-boy"
 homepage = "https://github.com/emu-rs/rustual-boy"
 
 [features]
-logging = []
+log-cli = []
+log-core-cpu = ["rustual-boy-core/log-cpu"]
+log-core-gamepad = ["rustual-boy-core/log-gamepad"]
+log-core-ic = ["rustual-boy-core/log-ic"]
+log-core-vip = ["rustual-boy-core/log-vip"]
+log-core-vsu = ["rustual-boy-core/log-vsu"]
+log-core-other = ["rustual-boy-core/log-other"]
+log-core-all = ["rustual-boy-core/log-all"]
 
 [dependencies]
 encoding = "0.2"

--- a/rustual-boy-cli/src/logging.rs
+++ b/rustual-boy-cli/src/logging.rs
@@ -1,25 +1,3 @@
-// This pass-through version should use $arg:tt rather than $arg:expr, but
-//  I've changed it to match the definition below, which needs the separate
-//  args, not just tokens. Otherwise, if there are any subtle differences
-//  between the tt/expr semantics, we may end up in a situation where the
-//  code compiles in one configuration, but not the other. So far, there
-//  haven't been any noticeable differences in this codebase. I'm guessing
-//  tt is used in the original println just for simplicity.
-
-#[macro_export]
-#[cfg(feature = "logging")]
-macro_rules! log {
-    ($fmt:expr) => (print!($fmt));
-    ($fmt:expr, $($arg:expr),*) => (print!($fmt, $($arg),*));
-}
-
-#[macro_export]
-#[cfg(feature = "logging")]
-macro_rules! logln {
-    ($fmt:expr) => (println!($fmt));
-    ($fmt:expr, $($arg:expr),*) => (println!($fmt, $($arg),*));
-}
-
 // When the logging feature is not used, these should effectively do nothing.
 //  However, if we simply ignore the arguments passed to the macro, we'll get
 //  a bunch of warnings about dead code, unused variables, etc. To get around
@@ -29,23 +7,19 @@ macro_rules! logln {
 //  be optimized away by the compiler.
 
 #[macro_export]
-#[cfg(not(feature = "logging"))]
 macro_rules! log {
-    ($fmt:expr) => (());
-    ($fmt:expr, $($arg:expr),*) => ({
-        $(
-            let _arg = &$arg;
-        )*
-    });
+ ($($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-cli")]
+    print!($($arg),*);
+ });
 }
 
 #[macro_export]
-#[cfg(not(feature = "logging"))]
 macro_rules! logln {
-    ($fmt:expr) => (());
-    ($fmt:expr, $($arg:expr),*) => ({
-        $(
-            let _arg = &$arg;
-        )*
-    });
+ ($($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-cli")]
+    println!($($arg),*);
+ });
 }

--- a/rustual-boy-core/Cargo.toml
+++ b/rustual-boy-core/Cargo.toml
@@ -9,7 +9,13 @@ repository = "https://github.com/emu-rs/rustual-boy"
 homepage = "https://github.com/emu-rs/rustual-boy"
 
 [features]
-logging = []
+log-cpu = []
+log-gamepad = []
+log-ic = []
+log-vip = []
+log-vsu = []
+log-other = []
+log-all = ["log-cpu", "log-gamepad", "log-ic", "log-vip", "log-vsu", "log-other"]
 
 [dependencies]
 encoding = "0.2"

--- a/rustual-boy-core/src/game_pad.rs
+++ b/rustual-boy-core/src/game_pad.rs
@@ -53,12 +53,12 @@ impl GamePad {
     }
 
     pub fn read_input_control_reg(&self) -> u8 {
-        logln!("WARNING: Read Game Pad Input Control Register not yet implemented");
+        logln!(Log::GamePad, "WARNING: Read Game Pad Input Control Register not yet implemented");
         0
     }
 
     pub fn write_input_control_reg(&mut self, value: u8) {
-        logln!("WARNING: Write Game Pad Input Control Register not yet implemented (value: 0x{:02x})", value);
+        logln!(Log::GamePad, "WARNING: Write Game Pad Input Control Register not yet implemented (value: 0x{:02x})", value);
     }
 
     pub fn read_input_low_reg(&self) -> u8 {

--- a/rustual-boy-core/src/interconnect.rs
+++ b/rustual-boy-core/src/interconnect.rs
@@ -37,19 +37,19 @@ impl Interconnect {
             VIP_START ... VIP_END => self.vip.read_byte(addr - VIP_START),
             VSU_START ... VSU_END => self.vsu.read_byte(addr - VSU_START),
             LINK_CONTROL_REG => {
-                logln!("WARNING: Read byte from Link Control Register not yet implemented");
+                logln!(Log::Ic, "WARNING: Read byte from Link Control Register not yet implemented");
                 0
             }
             AUX_LINK_REG => {
-                logln!("WARNING: Read byte from Auxiliary Link Register not yet implemented");
+                logln!(Log::Ic, "WARNING: Read byte from Auxiliary Link Register not yet implemented");
                 0
             }
             LINK_TRANSMIT_DATA_REG => {
-                logln!("Read byte from Link Transmit Data Register not yet implemented");
+                logln!(Log::Ic, "Read byte from Link Transmit Data Register not yet implemented");
                 0
             }
             LINK_RECEIVE_DATA_REG => {
-                logln!("Read byte from Link Receive Data Register not yet implemented");
+                logln!(Log::Ic, "Read byte from Link Receive Data Register not yet implemented");
                 0
             }
             GAME_PAD_INPUT_LOW_REG => self.game_pad.read_input_low_reg(),
@@ -58,12 +58,12 @@ impl Interconnect {
             TIMER_COUNTER_RELOAD_HIGH_REG => self.timer.read_counter_reload_high_reg(),
             TIMER_CONTROL_REG => self.timer.read_control_reg(),
             WAIT_CONTROL_REG => {
-                logln!("WARNING: Read byte from Wait Control Register not yet implemented");
+                logln!(Log::Ic, "WARNING: Read byte from Wait Control Register not yet implemented");
                 0
             }
             GAME_PAD_INPUT_CONTROL_REG => self.game_pad.read_input_control_reg(),
             CARTRIDGE_EXPANSION_START ... CARTRIDGE_EXPANSION_END => {
-                logln!("WARNING: Read byte from Cartridge Expansion not yet implemented (addr: 0x{:08x})", addr - CARTRIDGE_EXPANSION_START);
+                logln!(Log::Ic, "WARNING: Read byte from Cartridge Expansion not yet implemented (addr: 0x{:08x})", addr - CARTRIDGE_EXPANSION_START);
                 0
             }
             WRAM_START ... WRAM_END => self.wram.read_byte(addr - WRAM_START),
@@ -80,19 +80,19 @@ impl Interconnect {
             VIP_START ... VIP_END => self.vip.read_halfword(addr - VIP_START),
             VSU_START ... VSU_END => self.vsu.read_halfword(addr - VSU_START),
             LINK_CONTROL_REG => {
-                logln!("Read halfword from Link Control Register not yet implemented");
+                logln!(Log::Ic, "Read halfword from Link Control Register not yet implemented");
                 0
             }
             AUX_LINK_REG => {
-                logln!("Read halfword from Auxiliary Link Register not yet implemented");
+                logln!(Log::Ic, "Read halfword from Auxiliary Link Register not yet implemented");
                 0
             }
             LINK_TRANSMIT_DATA_REG => {
-                logln!("Read halfword from Link Transmit Data Register not yet implemented");
+                logln!(Log::Ic, "Read halfword from Link Transmit Data Register not yet implemented");
                 0
             }
             LINK_RECEIVE_DATA_REG => {
-                logln!("Read halfword from Link Receive Data Register not yet implemented");
+                logln!(Log::Ic, "Read halfword from Link Receive Data Register not yet implemented");
                 0
             }
             GAME_PAD_INPUT_LOW_REG => self.game_pad.read_input_low_reg() as _,
@@ -101,12 +101,12 @@ impl Interconnect {
             TIMER_COUNTER_RELOAD_HIGH_REG => self.timer.read_counter_reload_high_reg() as _,
             TIMER_CONTROL_REG => self.timer.read_control_reg() as _,
             WAIT_CONTROL_REG => {
-                logln!("Read halfword from Wait Control Register not yet implemented");
+                logln!(Log::Ic, "Read halfword from Wait Control Register not yet implemented");
                 0
             }
             GAME_PAD_INPUT_CONTROL_REG => self.game_pad.read_input_control_reg() as _,
             CARTRIDGE_EXPANSION_START ... CARTRIDGE_EXPANSION_END => {
-                logln!("WARNING: Read halfword from Cartridge Expansion not yet implemented (addr: 0x{:08x})", addr - CARTRIDGE_EXPANSION_START);
+                logln!(Log::Ic, "WARNING: Read halfword from Cartridge Expansion not yet implemented (addr: 0x{:08x})", addr - CARTRIDGE_EXPANSION_START);
                 0
             }
             WRAM_START ... WRAM_END => self.wram.read_halfword(addr - WRAM_START),
@@ -122,39 +122,39 @@ impl Interconnect {
             VIP_START ... VIP_END => self.vip.write_byte(addr - VIP_START, value),
             VSU_START ... VSU_END => self.vsu.write_byte(addr - VSU_START, value),
             LINK_CONTROL_REG => {
-                logln!("WARNING: Write byte to Link Control Register not yet implemented (value: 0x{:02x})", value);
+                logln!(Log::Ic, "WARNING: Write byte to Link Control Register not yet implemented (value: 0x{:02x})", value);
             }
             AUX_LINK_REG => {
-                logln!("WARNING: Write byte to Auxiliary Link Register not yet implemented (value: 0x{:02x})", value);
+                logln!(Log::Ic, "WARNING: Write byte to Auxiliary Link Register not yet implemented (value: 0x{:02x})", value);
             }
             LINK_TRANSMIT_DATA_REG => {
-                logln!("WARNING: Write byte to Link Transmit Data Register not yet implemented (value: 0x{:02x})", value);
+                logln!(Log::Ic, "WARNING: Write byte to Link Transmit Data Register not yet implemented (value: 0x{:02x})", value);
             }
             LINK_RECEIVE_DATA_REG => {
-                logln!("WARNING: Write byte to Link Receive Data Register not yet implemented (value: 0x{:02x})", value);
+                logln!(Log::Ic, "WARNING: Write byte to Link Receive Data Register not yet implemented (value: 0x{:02x})", value);
             }
             GAME_PAD_INPUT_LOW_REG => {
-                logln!("WARNING: Attempted write byte to Game Pad Input Low Register (value: 0x{:02x})", value);
+                logln!(Log::Ic, "WARNING: Attempted write byte to Game Pad Input Low Register (value: 0x{:02x})", value);
             }
             GAME_PAD_INPUT_HIGH_REG => {
-                logln!("WARNING: Attempted write byte to Game Pad Input High Register (value: 0x{:02x})", value);
+                logln!(Log::Ic, "WARNING: Attempted write byte to Game Pad Input High Register (value: 0x{:02x})", value);
             }
             TIMER_COUNTER_RELOAD_LOW_REG => self.timer.write_counter_reload_low_reg(value),
             TIMER_COUNTER_RELOAD_HIGH_REG => self.timer.write_counter_reload_high_reg(value),
             TIMER_CONTROL_REG => self.timer.write_control_reg(value),
             WAIT_CONTROL_REG => {
-                logln!("Wait Control Register (0x{:08x}) written: 0x{:02x}", addr, value);
-                logln!(" Cartridge ROM Waits: {}", if value & 0x01 == 0 { 2 } else { 1 });
-                logln!(" Cartridge Expansion Waits: {}", if value & 0x02 == 0 { 2 } else { 1 });
+                logln!(Log::Ic, "Wait Control Register (0x{:08x}) written: 0x{:02x}", addr, value);
+                logln!(Log::Ic, " Cartridge ROM Waits: {}", if value & 0x01 == 0 { 2 } else { 1 });
+                logln!(Log::Ic, " Cartridge Expansion Waits: {}", if value & 0x02 == 0 { 2 } else { 1 });
             }
             GAME_PAD_INPUT_CONTROL_REG => self.game_pad.write_input_control_reg(value),
             CARTRIDGE_EXPANSION_START ... CARTRIDGE_EXPANSION_END => {
-                logln!("WARNING: Write byte to Cartridge Expansion not yet implemented (addr: 0x{:08x}, value: 0x{:02x})", addr - CARTRIDGE_EXPANSION_START, value);
+                logln!(Log::Ic, "WARNING: Write byte to Cartridge Expansion not yet implemented (addr: 0x{:08x}, value: 0x{:02x})", addr - CARTRIDGE_EXPANSION_START, value);
             }
             WRAM_START ... WRAM_END => self.wram.write_byte(addr - WRAM_START, value),
             CARTRIDGE_RAM_START ... CARTRIDGE_RAM_END => self.sram.write_byte(addr - CARTRIDGE_RAM_START, value),
             CARTRIDGE_ROM_START ... CARTRIDGE_ROM_END => {
-                logln!("WARNING: Attempted write to Cartridge ROM at 0x{:08x}", addr - CARTRIDGE_ROM_START);
+                logln!(Log::Ic, "WARNING: Attempted write to Cartridge ROM at 0x{:08x}", addr - CARTRIDGE_ROM_START);
             }
             _ => panic!("Unrecognized addr: 0x{:08x}", addr)
         }
@@ -167,37 +167,37 @@ impl Interconnect {
             VIP_START ... VIP_END => self.vip.write_halfword(addr - VIP_START, value),
             VSU_START ... VSU_END => self.vsu.write_halfword(addr - VSU_START, value),
             LINK_CONTROL_REG => {
-                logln!("WARNING: Write halfword to Link Control Register not yet implemented (value: 0x{:04x})", value);
+                logln!(Log::Ic, "WARNING: Write halfword to Link Control Register not yet implemented (value: 0x{:04x})", value);
             }
             AUX_LINK_REG => {
-                logln!("WARNING: Write halfword to Auxiliary Link Register not yet implemented (value: 0x{:04x})", value);
+                logln!(Log::Ic, "WARNING: Write halfword to Auxiliary Link Register not yet implemented (value: 0x{:04x})", value);
             }
             LINK_TRANSMIT_DATA_REG => {
-                logln!("WARNING: Write halfword to Link Transmit Data Register not yet implemented (value: 0x{:04x})", value);
+                logln!(Log::Ic, "WARNING: Write halfword to Link Transmit Data Register not yet implemented (value: 0x{:04x})", value);
             }
             LINK_RECEIVE_DATA_REG => {
-                logln!("WARNING: Write halfword to Link Receive Data Register not yet implemented (value: 0x{:04x})", value);
+                logln!(Log::Ic, "WARNING: Write halfword to Link Receive Data Register not yet implemented (value: 0x{:04x})", value);
             }
             GAME_PAD_INPUT_LOW_REG => {
-                logln!("WARNING: Attempted halfword byte to Game Pad Input Low Register (value: 0x{:04x})", value);
+                logln!(Log::Ic, "WARNING: Attempted halfword byte to Game Pad Input Low Register (value: 0x{:04x})", value);
             }
             GAME_PAD_INPUT_HIGH_REG => {
-                logln!("WARNING: Attempted halfword byte to Game Pad Input High Register (value: 0x{:04x})", value);
+                logln!(Log::Ic, "WARNING: Attempted halfword byte to Game Pad Input High Register (value: 0x{:04x})", value);
             }
             TIMER_COUNTER_RELOAD_LOW_REG => self.timer.write_counter_reload_low_reg(value as _),
             TIMER_COUNTER_RELOAD_HIGH_REG => self.timer.write_counter_reload_high_reg(value as _),
             TIMER_CONTROL_REG => self.timer.write_control_reg(value as _),
             WAIT_CONTROL_REG => {
-                logln!("WARNING: Write halfword to Wait Control Register not yet implemented (value: 0x{:04x})", value);
+                logln!(Log::Ic, "WARNING: Write halfword to Wait Control Register not yet implemented (value: 0x{:04x})", value);
             }
             GAME_PAD_INPUT_CONTROL_REG => self.game_pad.write_input_control_reg(value as _),
             CARTRIDGE_EXPANSION_START ... CARTRIDGE_EXPANSION_END => {
-                logln!("WARNING: Write halfword to Cartridge Expansion not yet implemented (addr: 0x{:08x}, value: 0x{:04x})", addr - CARTRIDGE_EXPANSION_START, value);
+                logln!(Log::Ic, "WARNING: Write halfword to Cartridge Expansion not yet implemented (addr: 0x{:08x}, value: 0x{:04x})", addr - CARTRIDGE_EXPANSION_START, value);
             }
             WRAM_START ... WRAM_END => self.wram.write_halfword(addr - WRAM_START, value),
             CARTRIDGE_RAM_START ... CARTRIDGE_RAM_END => self.sram.write_halfword(addr - CARTRIDGE_RAM_START, value),
             CARTRIDGE_ROM_START ... CARTRIDGE_ROM_END => {
-                logln!("WARNING: Attempted write to Cartridge ROM at 0x{:08x}", addr - CARTRIDGE_ROM_START);
+                logln!(Log::Ic, "WARNING: Attempted write to Cartridge ROM at 0x{:08x}", addr - CARTRIDGE_ROM_START);
             }
             _ => panic!("Unrecognized addr: 0x{:08x}", addr)
         }

--- a/rustual-boy-core/src/logging.rs
+++ b/rustual-boy-core/src/logging.rs
@@ -1,51 +1,87 @@
-// This pass-through version should use $arg:tt rather than $arg:expr, but
-//  I've changed it to match the definition below, which needs the separate
-//  args, not just tokens. Otherwise, if there are any subtle differences
-//  between the tt/expr semantics, we may end up in a situation where the
-//  code compiles in one configuration, but not the other. So far, there
-//  haven't been any noticeable differences in this codebase. I'm guessing
-//  tt is used in the original println just for simplicity.
-
-#[macro_export]
-#[cfg(feature = "logging")]
-macro_rules! log {
-    ($fmt:expr) => (print!($fmt));
-    ($fmt:expr, $($arg:expr),*) => (print!($fmt, $($arg),*));
+// This enum is only referenced in macros and macro definations.  When macros
+//  get resolved it will remove the references to the enum in the generated
+//  code.  This has the effect of making the enum unused from the compiler's
+//  point of view.
+#[allow(dead_code)]
+pub enum Log {
+  Cpu,
+  GamePad,
+  Ic,
+  Vip,
+  Vsu,
 }
 
-#[macro_export]
-#[cfg(feature = "logging")]
-macro_rules! logln {
-    ($fmt:expr) => (println!($fmt));
-    ($fmt:expr, $($arg:expr),*) => (println!($fmt, $($arg),*));
-}
-
-// When the logging feature is not used, these should effectively do nothing.
+// When the logging features aren't used, these should effectively do nothing.
 //  However, if we simply ignore the arguments passed to the macro, we'll get
 //  a bunch of warnings about dead code, unused variables, etc. To get around
 //  this, we can bind all of the arguments in a local scope. However, simply
 //  binding the arguments will take ownership of them, which is not always
 //  desired, so we bind references to them instead. These bindings should
 //  be optimized away by the compiler.
-
 #[macro_export]
-#[cfg(not(feature = "logging"))]
 macro_rules! log {
-    ($fmt:expr) => (());
-    ($fmt:expr, $($arg:expr),*) => ({
-        $(
-            let _arg = &$arg;
-        )*
-    });
+ (Log::Cpu, $($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-cpu")]
+    print!($($arg),*);
+ });
+ (Log::GamePad, $($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-gamepad")]
+    print!($($arg),*);
+ });
+ (Log::Ic, $($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-ic")]
+    print!($($arg),*);
+ });
+ (Log::Vip, $($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-vip")]
+    print!($($arg),*);
+ });
+ (Log::Vsu, $($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-vsu")]
+    print!($($arg),*);
+ });
+ ($($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-other")]
+    print!($($arg),*);
+ });
 }
 
 #[macro_export]
-#[cfg(not(feature = "logging"))]
 macro_rules! logln {
-    ($fmt:expr) => (());
-    ($fmt:expr, $($arg:expr),*) => ({
-        $(
-            let _arg = &$arg;
-        )*
-    });
+ (Log::Cpu, $($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-cpu")]
+    println!($($arg),*);
+ });
+ (Log::GamePad, $($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-gamepad")]
+    println!($($arg),*);
+ });
+ (Log::Ic, $($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-ic")]
+    println!($($arg),*);
+ });
+ (Log::Vip, $($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-vip")]
+    println!($($arg),*);
+ });
+ (Log::Vsu, $($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-vsu")]
+    println!($($arg),*);
+ });
+ ($($arg:expr),*) => ({
+    $(let _arg = &$arg;)*
+    #[cfg(feature = "log-other")]
+    println!($($arg),*);
+ });
 }

--- a/rustual-boy-core/src/nvc.rs
+++ b/rustual-boy-core/src/nvc.rs
@@ -556,37 +556,37 @@ impl Nvc {
                             self.reg_eipsw = value;
                         }
                         OPCODE_SYSTEM_REGISTER_ID_FEPC => {
-                            logln!("WARNING: ldsr fepc not yet implemented (value: 0x{:08x})", value);
+                            logln!(Log::Cpu, "WARNING: ldsr fepc not yet implemented (value: 0x{:08x})", value);
                         }
                         OPCODE_SYSTEM_REGISTER_ID_FEPSW => {
-                            logln!("WARNING: ldsr fepsw not yet implemented (value: 0x{:08x})", value);
+                            logln!(Log::Cpu, "WARNING: ldsr fepsw not yet implemented (value: 0x{:08x})", value);
                         }
                         OPCODE_SYSTEM_REGISTER_ID_ECR => {
                             self.reg_ecr = value as _;
                         }
                         OPCODE_SYSTEM_REGISTER_ID_PSW => self.set_reg_psw(value),
                         OPCODE_SYSTEM_REGISTER_ID_CHCW => {
-                            logln!("WARNING: ldsr chcw not fully implemented (value: 0x{:08x})", value);
+                            logln!(Log::Cpu, "WARNING: ldsr chcw not fully implemented (value: 0x{:08x})", value);
                             let enable = (value >> 1) & 0x01 == 1;
                             if enable != self.cache.is_enabled() {
-                                logln!("ldsr chcw cache enable changed to {}", enable);
+                                logln!(Log::Cpu, "ldsr chcw cache enable changed to {}", enable);
                                 self.cache.set_is_enabled(enable);
                             }
 
                             if value & 0x01 == 1 {
                                 let entry_count = ((value >> 8) & 0x7ffff) as usize;
                                 let entry_start = (value >> 20) as usize;
-                                logln!("ldsr chcw request to clear cache for start entry: {}, entry count: {}", entry_start, entry_count);
+                                logln!(Log::Cpu, "ldsr chcw request to clear cache for start entry: {}, entry count: {}", entry_start, entry_count);
                                 self.cache.clear_entries(entry_start, entry_count);
                             } else if (value >> 4) & 0x01 == 1 {
                                 let addr = value & 0xffffff00;
-                                logln!("WARNING: ldsr chcw request to dump instruction cache to 0x{:08x} not implemented yet", addr);
+                                logln!(Log::Cpu, "WARNING: ldsr chcw request to dump instruction cache to 0x{:08x} not implemented yet", addr);
                             } else if (value >> 5) & 0x01 == 1 {
                                 let addr = value & 0xffffff00;
-                                logln!("WARNING: ldsr chcw request to restore instruction cache from 0x{:08x} not implemented yet", addr);
+                                logln!(Log::Cpu, "WARNING: ldsr chcw request to restore instruction cache from 0x{:08x} not implemented yet", addr);
                             }
                         }
-                        _ => logln!("WARNING: Unrecognized system register: {}", imm5),
+                        _ => logln!(Log::Cpu, "WARNING: Unrecognized system register: {}", imm5),
                     }
                 }),
                 OPCODE_BITS_STSR => format_ii!(|imm5, reg2| {
@@ -594,24 +594,24 @@ impl Nvc {
                         OPCODE_SYSTEM_REGISTER_ID_EIPC => self.reg_eipc,
                         OPCODE_SYSTEM_REGISTER_ID_EIPSW => self.reg_eipsw,
                         OPCODE_SYSTEM_REGISTER_ID_FEPC => {
-                            logln!("WARNING: stsr fepc not yet implemented");
+                            logln!(Log::Cpu, "WARNING: stsr fepc not yet implemented");
                             0
                         }
                         OPCODE_SYSTEM_REGISTER_ID_FEPSW => {
-                            logln!("WARNING: stsr fepsw not yet implemented");
+                            logln!(Log::Cpu, "WARNING: stsr fepsw not yet implemented");
                             0
                         }
                         OPCODE_SYSTEM_REGISTER_ID_ECR => self.reg_ecr as _,
                         OPCODE_SYSTEM_REGISTER_ID_PSW => self.reg_psw(),
                         OPCODE_SYSTEM_REGISTER_ID_CHCW => {
-                            logln!("WARNING: stsr chcw not fully implemented");
+                            logln!(Log::Cpu, "WARNING: stsr chcw not fully implemented");
                             match self.cache.is_enabled() {
                                 true => 2,
                                 false => 0,
                             }
                         }
                         _ => {
-                            logln!("WARNING: Unrecognized system register: {}", imm5);
+                            logln!(Log::Cpu, "WARNING: Unrecognized system register: {}", imm5);
                             0
                         }
                     };
@@ -945,7 +945,7 @@ impl Nvc {
     }
 
     fn enter_exception(&mut self, exception_code: u16) {
-        logln!("Entering exception (code: 0x{:04x})", exception_code);
+        logln!(Log::Cpu, "Entering exception (code: 0x{:04x})", exception_code);
         self.reg_eipc = self.reg_pc;
         self.reg_eipsw = self.reg_psw();
         self.reg_ecr = exception_code;
@@ -954,7 +954,7 @@ impl Nvc {
     }
 
     fn return_from_exception(&mut self) -> u32 {
-        logln!("Returning from exception (code: 0x{:04x})", self.reg_ecr);
+        logln!(Log::Cpu, "Returning from exception (code: 0x{:04x})", self.reg_ecr);
         let psw = self.reg_eipsw;
         self.set_reg_psw(psw);
         self.reg_eipc

--- a/rustual-boy-core/src/vip/mod.rs
+++ b/rustual-boy-core/src/vip/mod.rs
@@ -242,7 +242,7 @@ impl Vip {
         match addr {
             VRAM_START ... VRAM_END => self.read_vram_halfword(addr - VRAM_START),
             INTERRUPT_PENDING_REG => {
-                //logln!("WARNING: Read halfword from Interrupt Pending Reg not fully implemented");
+                //logln!(Log::Vip, "WARNING: Read halfword from Interrupt Pending Reg not fully implemented");
                 (if self.reg_interrupt_pending_left_display_finished { 1 } else { 0 } << 1) |
                 (if self.reg_interrupt_pending_right_display_finished { 1 } else { 0 } << 2) |
                 (if self.reg_interrupt_pending_start_of_game_frame { 1 } else { 0 } << 3) |
@@ -251,7 +251,7 @@ impl Vip {
                 (if self.reg_interrupt_pending_drawing_finished { 1 } else { 0 } << 14)
             }
             INTERRUPT_ENABLE_REG => {
-                logln!("WARNING: Read halfword from Interrupt Enable Reg not fully implemented");
+                logln!(Log::Vip, "WARNING: Read halfword from Interrupt Enable Reg not fully implemented");
                 (if self.reg_interrupt_enable_left_display_finished { 1 } else { 0 } << 1) |
                 (if self.reg_interrupt_enable_right_display_finished { 1 } else { 0 } << 2) |
                 (if self.reg_interrupt_enable_start_of_game_frame { 1 } else { 0 } << 3) |
@@ -260,7 +260,7 @@ impl Vip {
                 (if self.reg_interrupt_enable_drawing_finished { 1 } else { 0 } << 14)
             }
             INTERRUPT_CLEAR_REG => {
-                logln!("WARNING: Attempted read halfword from Interrupt Clear Reg");
+                logln!(Log::Vip, "WARNING: Attempted read halfword from Interrupt Clear Reg");
                 0
             }
             DISPLAY_CONTROL_READ_REG => {
@@ -286,14 +286,14 @@ impl Vip {
                 (if column_table_addr_lock { 1 } else { 0 } << 10)
             }
             DISPLAY_CONTROL_WRITE_REG => {
-                logln!("WARNING: Attempted read halfword from Display Control Write Reg");
+                logln!(Log::Vip, "WARNING: Attempted read halfword from Display Control Write Reg");
                 0
             }
             LED_BRIGHTNESS_1_REG => self.reg_led_brightness_1 as _,
             LED_BRIGHTNESS_2_REG => self.reg_led_brightness_2 as _,
             LED_BRIGHTNESS_3_REG => self.reg_led_brightness_3 as _,
             LED_BRIGHTNESS_IDLE_REG => {
-                logln!("WARNING: Read halfword from LED Brightness Idle Reg not yet implemented");
+                logln!(Log::Vip, "WARNING: Read halfword from LED Brightness Idle Reg not yet implemented");
                 0
             }
             GAME_FRAME_CONTROL_REG => {
@@ -321,7 +321,7 @@ impl Vip {
                 (if self.reg_drawing_control_sbout { 1 } else { 0 } << 15)
             }
             DRAWING_CONTROL_WRITE_REG => {
-                logln!("WARNING: Attempted read halfword from Drawing Control Write Reg");
+                logln!(Log::Vip, "WARNING: Attempted read halfword from Drawing Control Write Reg");
                 0
             }
             OBJ_GROUP_0_POINTER_REG => self.reg_obj_group_0_ptr,
@@ -346,7 +346,7 @@ impl Vip {
             CHR_RAM_PATTERN_TABLE_3_MIRROR_START ... CHR_RAM_PATTERN_TABLE_3_MIRROR_END =>
                 self.read_vram_halfword(addr - CHR_RAM_PATTERN_TABLE_3_MIRROR_START + CHR_RAM_PATTERN_TABLE_3_START),
             _ => {
-                logln!("WARNING: Attempted read halfword from unrecognized VIP address (addr: 0x{:08x})", addr);
+                logln!(Log::Vip, "WARNING: Attempted read halfword from unrecognized VIP address (addr: 0x{:08x})", addr);
                 0
             }
         }
@@ -358,10 +358,10 @@ impl Vip {
         match addr {
             VRAM_START ... VRAM_END => self.write_vram_halfword(addr - VRAM_START, value),
             INTERRUPT_PENDING_REG => {
-                logln!("WARNING: Attempted write halfword to Interrupt Pending Reg");
+                logln!(Log::Vip, "WARNING: Attempted write halfword to Interrupt Pending Reg");
             }
             INTERRUPT_ENABLE_REG => {
-                logln!("WARNING: Write halfword to Interrupt Enable Reg not fully implemented (value: 0x{:04x})", value);
+                logln!(Log::Vip, "WARNING: Write halfword to Interrupt Enable Reg not fully implemented (value: 0x{:04x})", value);
                 self.reg_interrupt_enable_left_display_finished = (value & 0x0002) != 0;
                 self.reg_interrupt_enable_right_display_finished = (value & 0x0004) != 0;
                 self.reg_interrupt_enable_start_of_game_frame = (value & 0x0008) != 0;
@@ -370,7 +370,7 @@ impl Vip {
                 self.reg_interrupt_enable_drawing_finished = (value & 0x4000) != 0;
             }
             INTERRUPT_CLEAR_REG => {
-                logln!("WARNING: Write halfword to Interrupt Clear Reg not fully implemented (value: 0x{:04x})", value);
+                logln!(Log::Vip, "WARNING: Write halfword to Interrupt Clear Reg not fully implemented (value: 0x{:04x})", value);
                 if (value & 0x0002) != 0 {
                     self.reg_interrupt_pending_left_display_finished = false;
                 }
@@ -391,10 +391,10 @@ impl Vip {
                 }
             }
             DISPLAY_CONTROL_READ_REG => {
-                logln!("WARNING: Attempted write halfword to Display Control Read Reg");
+                logln!(Log::Vip, "WARNING: Attempted write halfword to Display Control Read Reg");
             }
             DISPLAY_CONTROL_WRITE_REG => {
-                logln!("WARNING: Write halfword to Display Control Write Reg not fully implemented (value: 0x{:04x})", value);
+                logln!(Log::Vip, "WARNING: Write halfword to Display Control Write Reg not fully implemented (value: 0x{:04x})", value);
 
                 let reset = (value & 0x0001) != 0;
                 let enable = (value & 0x0002) != 0;
@@ -419,17 +419,17 @@ impl Vip {
             LED_BRIGHTNESS_2_REG => self.reg_led_brightness_2 = value as _,
             LED_BRIGHTNESS_3_REG => self.reg_led_brightness_3 = value as _,
             LED_BRIGHTNESS_IDLE_REG => {
-                logln!("WARNING: Write halfword to LED Brightness Idle Reg not yet implemented (value: 0x{:04x})", value);
+                logln!(Log::Vip, "WARNING: Write halfword to LED Brightness Idle Reg not yet implemented (value: 0x{:04x})", value);
             }
             GAME_FRAME_CONTROL_REG => {
-                logln!("Game Frame Control written (value: 0x{:04x})", value);
+                logln!(Log::Vip, "Game Frame Control written (value: 0x{:04x})", value);
                 self.reg_game_frame_control = (value as usize) + 1;
             }
             DRAWING_CONTROL_READ_REG => {
-                logln!("WARNING: Attempted write halfword to Drawing Control Read Reg (value: 0x{:04x})", value);
+                logln!(Log::Vip, "WARNING: Attempted write halfword to Drawing Control Read Reg (value: 0x{:04x})", value);
             }
             DRAWING_CONTROL_WRITE_REG => {
-                logln!("WARNING: Write halfword to Drawing Control Write Reg not fully implemented (value: 0x{:04x})", value);
+                logln!(Log::Vip, "WARNING: Write halfword to Drawing Control Write Reg not fully implemented (value: 0x{:04x})", value);
 
                 let reset = (value & 0x01) != 0;
                 self.reg_drawing_control_drawing_enable = (value & 0x02) != 0;
@@ -464,7 +464,7 @@ impl Vip {
             CHR_RAM_PATTERN_TABLE_3_MIRROR_START ... CHR_RAM_PATTERN_TABLE_3_MIRROR_END =>
                 self.write_vram_halfword(addr - CHR_RAM_PATTERN_TABLE_3_MIRROR_START + CHR_RAM_PATTERN_TABLE_3_START, value),
             _ => {
-                logln!("WARNING: Attempted write halfword to unrecognized VIP address (addr: 0x{:08x}, value: 0x{:04x})", addr, value);
+                logln!(Log::Vip, "WARNING: Attempted write halfword to unrecognized VIP address (addr: 0x{:08x}, value: 0x{:04x})", addr, value);
             }
         }
     }
@@ -586,7 +586,7 @@ impl Vip {
     }
 
     fn frame_clock(&mut self, raise_interrupt: &mut bool) {
-        logln!("Frame clock rising edge");
+        logln!(Log::Vip, "Frame clock rising edge");
 
         if self.reg_display_control_display_enable {
             self.reg_interrupt_pending_start_of_display_frame = true;
@@ -605,7 +605,7 @@ impl Vip {
     }
 
     fn game_clock(&mut self, raise_interrupt: &mut bool) {
-        logln!("Game clock rising edge");
+        logln!(Log::Vip, "Game clock rising edge");
 
         self.reg_interrupt_pending_start_of_game_frame = true;
         if self.reg_interrupt_enable_start_of_game_frame {
@@ -625,7 +625,7 @@ impl Vip {
     }
 
     fn begin_drawing_process(&mut self) {
-        logln!("Begin drawing process");
+        logln!(Log::Vip, "Begin drawing process");
         self.drawing_state = DrawingState::Drawing;
 
         self.reg_drawing_control_sbcount = 0;
@@ -636,11 +636,11 @@ impl Vip {
     }
 
     fn begin_drawing_block(&mut self) {
-        logln!("Begin drawing block {}", self.reg_drawing_control_sbcount);
+        logln!(Log::Vip, "Begin drawing block {}", self.reg_drawing_control_sbcount);
     }
 
     fn end_drawing_block(&mut self, raise_interrupt: &mut bool) {
-        logln!("End drawing block {}", self.reg_drawing_control_sbcount);
+        logln!(Log::Vip, "End drawing block {}", self.reg_drawing_control_sbcount);
 
         self.draw_current_block();
 
@@ -656,27 +656,27 @@ impl Vip {
     }
 
     fn end_drawing_process(&mut self) {
-        logln!("End drawing process");
+        logln!(Log::Vip, "End drawing process");
         self.drawing_state = DrawingState::Idle;
     }
 
     fn begin_display_process(&mut self) {
-        logln!("Start display process");
+        logln!(Log::Vip, "Start display process");
         self.display_state = DisplayState::Idle;
     }
 
     fn begin_left_framebuffer_display_process(&mut self) {
-        logln!("Start left framebuffer display process");
+        logln!(Log::Vip, "Start left framebuffer display process");
         self.display_state = DisplayState::LeftFramebuffer;
     }
 
     fn begin_right_framebuffer_display_process(&mut self) {
-        logln!("Start right framebuffer display process");
+        logln!(Log::Vip, "Start right framebuffer display process");
         self.display_state = DisplayState::RightFramebuffer;
     }
 
     fn end_display_process(&mut self) {
-        logln!("End display process");
+        logln!(Log::Vip, "End display process");
         self.display_state = DisplayState::Finished;
     }
 
@@ -705,13 +705,13 @@ impl Vip {
         let mut window_offset = WINDOW_ATTRIBS_END + 1 - WINDOW_ENTRY_LENGTH;
         let mut window_index = 31;
         for _ in 0..32 {
-            logln!("Window {}", window_index);
+            logln!(Log::Vip, "Window {}", window_index);
 
             let header = self.read_vram_halfword(window_offset);
-            logln!(" Header: 0x{:04x}", header);
+            logln!(Log::Vip, " Header: 0x{:04x}", header);
 
             if header == 0 {
-                logln!("  [Dummy world]");
+                logln!(Log::Vip, "  [Dummy world]");
             } else {
                 let base = (header & 0x000f) as u32;
                 let stop = (header & 0x0040) != 0;
@@ -721,12 +721,12 @@ impl Vip {
                 let mode = ((header >> 12) & 0x03) as usize;
                 let right_on = (header & 0x4000) != 0;
                 let left_on = (header & 0x8000) != 0;
-                /*logln!("  base: 0x{:02x}", base);
-                logln!("  stop: {}", stop);
-                logln!("  out of bounds: {}", out_of_bounds);
-                logln!("  w, h: {}, {}", bg_width, bg_height);
-                logln!("  mode: {}", mode);
-                logln!("  l, r: {}, {}", left_on, right_on);*/
+                /*logln!(Log::Vip, "  base: 0x{:02x}", base);
+                logln!(Log::Vip, "  stop: {}", stop);
+                logln!(Log::Vip, "  out of bounds: {}", out_of_bounds);
+                logln!(Log::Vip, "  w, h: {}, {}", bg_width, bg_height);
+                logln!(Log::Vip, "  mode: {}", mode);
+                logln!(Log::Vip, "  l, r: {}, {}", left_on, right_on);*/
 
                 let x = self.read_vram_halfword(window_offset + 2) as i16;
                 let parallax = self.read_vram_halfword(window_offset + 4) as i16;
@@ -738,16 +738,16 @@ impl Vip {
                 let height = self.read_vram_halfword(window_offset + 16);
                 let param_base = self.read_vram_halfword(window_offset + 18) as u32;
                 let out_of_bounds_char = self.read_vram_halfword(window_offset + 20);
-                /*logln!(" X: {}", x);
-                logln!(" Parallax: {}", parallax);
-                logln!(" Y: {}", y);
-                logln!(" BG X: {}", bg_x);
-                logln!(" BG Parallax: {}", bg_parallax);
-                logln!(" BG Y: {}", bg_y);
-                logln!(" Width: {}", width);
-                logln!(" Height: {}", height);
-                logln!(" Param base: 0x{:04x}", param_base);
-                logln!(" Out of bounds char: 0x{:04x}", out_of_bounds_char);*/
+                /*logln!(Log::Vip, " X: {}", x);
+                logln!(Log::Vip, " Parallax: {}", parallax);
+                logln!(Log::Vip, " Y: {}", y);
+                logln!(Log::Vip, " BG X: {}", bg_x);
+                logln!(Log::Vip, " BG Parallax: {}", bg_parallax);
+                logln!(Log::Vip, " BG Y: {}", bg_y);
+                logln!(Log::Vip, " Width: {}", width);
+                logln!(Log::Vip, " Height: {}", height);
+                logln!(Log::Vip, " Param base: 0x{:04x}", param_base);
+                logln!(Log::Vip, " Out of bounds char: 0x{:04x}", out_of_bounds_char);*/
 
                 if stop {
                     break;
@@ -794,7 +794,7 @@ impl Vip {
 
                     match mode {
                         WindowMode::Obj => {
-                            //logln!("Current obj group: {:?}", current_obj_group);
+                            //logln!(Log::Vip, "Current obj group: {:?}", current_obj_group);
 
                             match current_obj_group {
                                 Some(obj_group) => {
@@ -814,7 +814,7 @@ impl Vip {
                                         ending_obj_index = 0;
                                     }
                                     for i in (ending_obj_index..starting_obj_index + 1).rev() {
-                                        //logln!("Current obj: {}", i);
+                                        //logln!(Log::Vip, "Current obj: {}", i);
 
                                         let obj_offset = 0x0003e000 + (i as u32) * 8;
 
@@ -829,15 +829,15 @@ impl Vip {
                                         let horizontal_flip = (pal_hf_vf_char & 0x2000) != 0;
                                         let vertical_flip = (pal_hf_vf_char & 0x1000) != 0;
                                         let char_index = (pal_hf_vf_char & 0x07ff) as u32;
-                                        /*logln!(" X: {}", x);
-                                        logln!(" L: {}", l);
-                                        logln!(" R: {}", r);
-                                        logln!(" Parallax: {}", parallax);
-                                        logln!(" Y: {}", y);
-                                        logln!(" Pal: {}", pal);
-                                        logln!(" Horizontal flip: {}", horizontal_flip);
-                                        logln!(" Vertical flip: {}", vertical_flip);
-                                        logln!(" Char index: {}", char_index);*/
+                                        /*logln!(Log::Vip, " X: {}", x);
+                                        logln!(Log::Vip, " L: {}", l);
+                                        logln!(Log::Vip, " R: {}", r);
+                                        logln!(Log::Vip, " Parallax: {}", parallax);
+                                        logln!(Log::Vip, " Y: {}", y);
+                                        logln!(Log::Vip, " Pal: {}", pal);
+                                        logln!(Log::Vip, " Horizontal flip: {}", horizontal_flip);
+                                        logln!(Log::Vip, " Vertical flip: {}", vertical_flip);
+                                        logln!(Log::Vip, " Char index: {}", char_index);*/
 
                                         match eye {
                                             Eye::Left => {
@@ -881,7 +881,7 @@ impl Vip {
                                         }
                                     }
                                 }
-                                _ => logln!("WARNING: Extra obj window found; all obj groups already drawn")
+                                _ => logln!(Log::Vip, "WARNING: Extra obj window found; all obj groups already drawn")
                             }
                         }
                         WindowMode::Affine => {

--- a/rustual-boy-core/src/vsu/mod.rs
+++ b/rustual-boy-core/src/vsu/mod.rs
@@ -523,7 +523,7 @@ impl Vsu {
     }
 
     pub fn read_byte(&self, addr: u32) -> u8 {
-        logln!("WARNING: Attempted read byte from VSU (addr: 0x{:08x})", addr);
+        logln!(Log::Vsu, "WARNING: Attempted read byte from VSU (addr: 0x{:08x})", addr);
 
         0
     }
@@ -612,12 +612,12 @@ impl Vsu {
                     self.voice6.reg_play_control.enable = false;
                 }
             }
-            _ => logln!("VSU write byte not yet implemented (addr: 0x{:08x}, value: 0x{:04x})", addr, value)
+            _ => logln!(Log::Vsu, "VSU write byte not yet implemented (addr: 0x{:08x}, value: 0x{:04x})", addr, value)
         }
     }
 
     pub fn read_halfword(&self, addr: u32) -> u16 {
-        logln!("WARNING: Attempted read halfword from VSU (addr: 0x{:08x})", addr);
+        logln!(Log::Vsu, "WARNING: Attempted read halfword from VSU (addr: 0x{:08x})", addr);
 
         0
     }


### PR DESCRIPTION
log(ln)! macros in the core were update to accept additional formats that
support the first param being the Log enum.  The existing 'logging' feature
in the core was replaced with the follow features for the different subsystems.

log-cpu
log-gamepad
log-ic
log-vip
log-vsu
log-other (anything not passing the Log enum to the log(ln)! macros)
log-all

Since the core is a dependency of the cli it was necessary to add features
the cli's Cargo.toml to pass along enabling the log feature(s) to the core.
The following names were used for this in the cli.

log-core-cpu
log-core-gamepad
log-core-ic
...

The cli's 'logging' feature was renamed to 'log-cli' to give it the same
naming convention as the core.  The log(ln)! macros in the cli were also
updated to be the same style as the core, minus the Log enum bits.