### PR TITLE
Add append_to() to MostRecentSink

### DIFF
--- a/rustual-boy-middleware/src/most_recent_sink.rs
+++ b/rustual-boy-middleware/src/most_recent_sink.rs
@@ -19,6 +19,10 @@ impl<T> MostRecentSink<T> {
     pub fn into_inner(self) -> Option<T> {
         self.inner
     }
+
+    pub fn append_to(self, target: &mut Sink<T>) {
+        target.append(self.into_inner().unwrap())
+    }
 }
 
 impl<T> Sink<T> for MostRecentSink<T> {


### PR DESCRIPTION
Not a blocker or anything, but figured it is a common enough case. This just allows my code to be a _teeny tiny bit cleaner_ :)