### PR TITLE
Fix display of opcodes that use a signed imm5 in debugger

### DIFF
--- a/rustual-boy-cli/src/emulator.rs
+++ b/rustual-boy-cli/src/emulator.rs
@@ -380,6 +380,7 @@ impl Emulator {
                     Opcode::Cli | Opcode::Reti | Opcode::Halt | Opcode::Sei => println!("{}", opcode),
                     Opcode::Ldsr => println!("{} r{}, {}", opcode, reg2, opcode.system_register(imm5)),
                     Opcode::Stsr => println!("{} {}, r{}", opcode, opcode.system_register(imm5), reg2),
+                    Opcode::MovImm | Opcode::AddImm5 | Opcode::CmpImm => println!("{} {}, r{}", opcode, (((imm5 as i32) << 27) >> 27), reg2),
                     _ => println!("{} {}, r{}", opcode, imm5, reg2)
                 }
             }


### PR DESCRIPTION
mov/add/cmp use a signed imm5 value, but the debugger is displaying
them as unsigned.  This update sign extends the imm5 value for those
opcodes to fix the displayed value.