### PR TITLE
Massive save state speedup

### DIFF
--- a/rustual-boy-libretro/src/lib.rs
+++ b/rustual-boy-libretro/src/lib.rs
@@ -33,7 +33,6 @@ use system_info::*;
 
 use std::{mem, ptr};
 use std::slice;
-use std::cell::RefCell;
 
 pub enum OutputBuffer {
     Xrgb1555(Vec<u16>),
@@ -61,7 +60,7 @@ pub struct Context {
     system: Option<System>,
     video_output_frame_buffer: OutputBuffer,
     audio_frame_buffer: Vec<AudioFrame>,
-    last_serialized_state: RefCell<Option<Vec<u8>>>,
+    last_serialized_state: Option<Vec<u8>>,
 }
 
 impl Context {
@@ -70,12 +69,12 @@ impl Context {
             system: None,
             video_output_frame_buffer: OutputBuffer::Xrgb1555(vec![0; DISPLAY_PIXELS as usize]),
             audio_frame_buffer: vec![(0, 0); (SAMPLE_RATE as usize) / 50 * 2], // double space needed for 1 frame for lots of skid room
-            last_serialized_state: RefCell::new(None),
+            last_serialized_state: None,
         }
     }
 
     fn load_game(&mut self, game_info: &GameInfo) -> bool {
-        *self.last_serialized_state.get_mut() = None;
+        self.last_serialized_state = None;
         unsafe {
             // It seems retroarch (and possibly other frontends) is a bit finicky with accepting the set pixel format
             //  callback, so we should call it a few times before giving up. We don't want to loop forever here though,
@@ -114,7 +113,7 @@ impl Context {
     }
 
     fn unload_game(&mut self) {
-        *self.last_serialized_state.get_mut() = None;
+        self.last_serialized_state = None;
         self.system = None;
     }
 
@@ -137,14 +136,14 @@ impl Context {
     }
 
     fn reset(&mut self) {
-        *self.last_serialized_state.get_mut() = None;
+        self.last_serialized_state = None;
         // Pull out rom/sram from existing system, and build new system around them
         let (rom, sram) = self.system.as_ref().map(|system| (system.virtual_boy.interconnect.rom.clone(), system.virtual_boy.interconnect.sram.clone())).unwrap();
         self.system = Some(System::new(rom, sram));
     }
 
     fn run_frame(&mut self) {
-        *self.last_serialized_state.get_mut() = None;
+        self.last_serialized_state = None;
         unsafe {
             CALLBACKS.input_poll();
 
@@ -226,8 +225,8 @@ impl Context {
         }
     }
 
-    fn get_serialized_size(&self) -> size_t {
-        if let Some(ref serialized_bytes) = *self.last_serialized_state.borrow() {
+    fn get_serialized_size(&mut self) -> size_t {
+        if let Some(ref serialized_bytes) = self.last_serialized_state {
             return serialized_bytes.len();
         }
         
@@ -236,7 +235,7 @@ impl Context {
             match serialize(state) {
                 Ok(serialized_bytes) => {
                     let len = serialized_bytes.len();
-                    *self.last_serialized_state.borrow_mut() = Some(serialized_bytes);
+                    self.last_serialized_state = Some(serialized_bytes);
                     len
                 }
                 Err(err) => {
@@ -251,8 +250,8 @@ impl Context {
         }
     }
 
-    fn serialize(&self, data: *mut c_void, size: size_t) -> bool {
-        if let Some(ref serialized_bytes) = *self.last_serialized_state.borrow() {
+    fn serialize(&mut self, data: *mut c_void, size: size_t) -> bool {
+        if let Some(ref serialized_bytes) = self.last_serialized_state {
             let result = serialized_bytes.len() <= size;
             if result {
                 unsafe { ptr::copy_nonoverlapping(serialized_bytes.as_ptr(), data as *mut u8, serialized_bytes.len()) };
@@ -265,7 +264,7 @@ impl Context {
                 Ok(serialized_bytes) => {
                     if serialized_bytes.len() <= size {
                         unsafe { ptr::copy_nonoverlapping(serialized_bytes.as_ptr(), data as *mut u8, serialized_bytes.len()) };
-                        *self.last_serialized_state.borrow_mut() = Some(serialized_bytes);
+                        self.last_serialized_state = Some(serialized_bytes);
 
                         true
                     } else {
@@ -285,7 +284,7 @@ impl Context {
     }
 
     fn unserialize(&mut self, data: *const c_void, size: size_t) -> bool {
-        *self.last_serialized_state.get_mut() = None;
+        self.last_serialized_state = None;
         let data_slice = unsafe { slice::from_raw_parts(data as *const u8, size) };
         match deserialize(data_slice) {
             Ok(deserialized_state) => {

--- a/rustual-boy-libretro/src/lib.rs
+++ b/rustual-boy-libretro/src/lib.rs
@@ -33,6 +33,7 @@ use system_info::*;
 
 use std::{mem, ptr};
 use std::slice;
+use std::cell::RefCell;
 
 pub enum OutputBuffer {
     Xrgb1555(Vec<u16>),
@@ -60,6 +61,7 @@ pub struct Context {
     system: Option<System>,
     video_output_frame_buffer: OutputBuffer,
     audio_frame_buffer: Vec<AudioFrame>,
+    last_serialized_state: RefCell<Option<Vec<u8>>>,
 }
 
 impl Context {
@@ -68,10 +70,12 @@ impl Context {
             system: None,
             video_output_frame_buffer: OutputBuffer::Xrgb1555(vec![0; DISPLAY_PIXELS as usize]),
             audio_frame_buffer: vec![(0, 0); (SAMPLE_RATE as usize) / 50 * 2], // double space needed for 1 frame for lots of skid room
+            last_serialized_state: RefCell::new(None),
         }
     }
 
     fn load_game(&mut self, game_info: &GameInfo) -> bool {
+        *self.last_serialized_state.get_mut() = None;
         unsafe {
             // It seems retroarch (and possibly other frontends) is a bit finicky with accepting the set pixel format
             //  callback, so we should call it a few times before giving up. We don't want to loop forever here though,
@@ -110,6 +114,7 @@ impl Context {
     }
 
     fn unload_game(&mut self) {
+        *self.last_serialized_state.get_mut() = None;
         self.system = None;
     }
 
@@ -132,12 +137,14 @@ impl Context {
     }
 
     fn reset(&mut self) {
+        *self.last_serialized_state.get_mut() = None;
         // Pull out rom/sram from existing system, and build new system around them
         let (rom, sram) = self.system.as_ref().map(|system| (system.virtual_boy.interconnect.rom.clone(), system.virtual_boy.interconnect.sram.clone())).unwrap();
         self.system = Some(System::new(rom, sram));
     }
 
     fn run_frame(&mut self) {
+        *self.last_serialized_state.get_mut() = None;
         unsafe {
             CALLBACKS.input_poll();
 
@@ -220,10 +227,18 @@ impl Context {
     }
 
     fn get_serialized_size(&self) -> size_t {
+        if let Some(ref serialized_bytes) = *self.last_serialized_state.borrow() {
+            return serialized_bytes.len();
+        }
+        
         if let Some(ref system) = self.system {
             let state = get_state(&system.virtual_boy);
             match serialize(state) {
-                Ok(serialized_bytes) => serialized_bytes.len() as _,
+                Ok(serialized_bytes) => {
+                    let len = serialized_bytes.len();
+                    *self.last_serialized_state.borrow_mut() = Some(serialized_bytes);
+                    len
+                }
                 Err(err) => {
                     // TODO: Remove this..?
                     println!("****** RUH ROH: Serialization failed for some reason :((( {}", err);
@@ -237,12 +252,20 @@ impl Context {
     }
 
     fn serialize(&self, data: *mut c_void, size: size_t) -> bool {
+        if let Some(ref serialized_bytes) = *self.last_serialized_state.borrow() {
+            let result = serialized_bytes.len() <= size;
+            if result {
+                unsafe { ptr::copy_nonoverlapping(serialized_bytes.as_ptr(), data as *mut u8, serialized_bytes.len()) };
+            }
+            return result;
+        }
         if let Some(ref system) = self.system {
             let state = get_state(&system.virtual_boy);
             match serialize(state) {
                 Ok(serialized_bytes) => {
-                    if serialized_bytes.len() == size {
-                        unsafe { ptr::copy_nonoverlapping(serialized_bytes.as_ptr(), data as *mut u8, size) };
+                    if serialized_bytes.len() <= size {
+                        unsafe { ptr::copy_nonoverlapping(serialized_bytes.as_ptr(), data as *mut u8, serialized_bytes.len()) };
+                        *self.last_serialized_state.borrow_mut() = Some(serialized_bytes);
 
                         true
                     } else {
@@ -262,6 +285,7 @@ impl Context {
     }
 
     fn unserialize(&mut self, data: *const c_void, size: size_t) -> bool {
+        *self.last_serialized_state.get_mut() = None;
         let data_slice = unsafe { slice::from_raw_parts(data as *const u8, size) };
         match deserialize(data_slice) {
             Ok(deserialized_state) => {

--- a/rustual-boy-serialization/Cargo.lock
+++ b/rustual-boy-serialization/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "lz4 1.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustual-boy-core 0.1.0",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -279,6 +280,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_bytes"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"
@@ -423,6 +432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
+"checksum serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adb6e51a6b3696b301bc221d785f898b4457c619b51d7ce195a6d20baecb37b3"
 "checksum serde_derive 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "23b163a6ce7e1aa897919f9d8e40bd1f8a6f95342ed57727ae31387a01a7a356"
 "checksum serde_derive_internals 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "370aa477297975243dc914d0b0e1234927520ec311de507a560fbd1c80f7ab8c"
 "checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"

--- a/rustual-boy-serialization/Cargo.toml
+++ b/rustual-boy-serialization/Cargo.toml
@@ -7,5 +7,6 @@ authors = ["ferris <yupferris@gmail.com>"]
 rustual-boy-core = { path="../rustual-boy-core" }
 serde = "1.0"
 serde_derive = "1.0"
+serde_bytes="0.10"
 bincode = "1.0"
 lz4 = "*"

--- a/rustual-boy-serialization/src/lib.rs
+++ b/rustual-boy-serialization/src/lib.rs
@@ -10,6 +10,7 @@ extern crate bincode;
 extern crate lz4;
 
 pub mod version1;
+mod serde_ibytes;
 
 use lz4::{EncoderBuilder, Decoder};
 

--- a/rustual-boy-serialization/src/lib.rs
+++ b/rustual-boy-serialization/src/lib.rs
@@ -13,9 +13,6 @@ pub mod version1;
 
 use lz4::{EncoderBuilder, Decoder};
 
-use std::io::{copy, Cursor};
-use std::time::Instant;
-
 use rustual_boy_core::rom::*;
 use rustual_boy_core::timer::*;
 use rustual_boy_core::vip::*;
@@ -37,30 +34,24 @@ pub enum ApplyError {
 }
 
 pub fn serialize(state: State) -> Result<Vec<u8>, String> {
-    let start_time = Instant::now();
     let versioned_state = VersionedState::Version1(state);
-    let bincode = bincode::serialize(&versioned_state).map_err(|e| format!("Couldn't serialize bincode: {}", e))?;
-    let bin_time = Instant::now();
-    let mut cursor = Cursor::new(bincode);
-    let encoded = Vec::new();
-    let mut encoder = EncoderBuilder::new().build(encoded).map_err(|e| format!("Couldn't build lz4 encoder: {}", e))?;
-    copy(&mut cursor, &mut encoder).map_err(|e| format!("Couldn't encode lz4: {}", e))?;
+    let encoded = Vec::with_capacity(512 * 1024);
+    let mut encoder = EncoderBuilder::new()
+        .level(2)
+        .block_size(lz4::BlockSize::Max1MB)
+        .build(encoded)
+        .map_err(|e| format!("Couldn't build lz4 encoder: {}", e))?;
+    bincode::serialize_into(&mut encoder, &versioned_state).map_err(|e| format!("Couldn't save state: {}", e))?;
     let (encoded, result) = encoder.finish();
     if let Err(e) = result {
         return Err(format!("Couldn't finish lz4 encoding: {}", e));
     }
-    let lz4_time = Instant::now();
-    eprintln!("bincode: {:?}", bin_time - start_time);
-    eprintln!("lz4    : {:?}", lz4_time - bin_time);
-    eprintln!("total  : {:?}", lz4_time - start_time);
     Ok(encoded)
 }
 
 pub fn deserialize(encoded: &[u8]) -> Result<State, String> {
-    let mut decoder = Decoder::new(encoded).map_err(|e| format!("Couldn't build lz4 decoder: {}", e))?;
-    let mut bincode = Vec::new();
-    copy(&mut decoder, &mut bincode).map_err(|e| format!("Couldn't decode lz4: {}", e))?;
-    let versioned_state = bincode::deserialize(&bincode).map_err(|e| format!("Couldn't deserialize bincode: {}", e))?;
+    let decoder = Decoder::new(encoded).map_err(|e| format!("Couldn't build lz4 decoder: {}", e))?;
+    let versioned_state = bincode::deserialize_from(decoder).map_err(|e| format!("Couldn't deserialize state: {}", e))?;
     Ok(match versioned_state {
         VersionedState::Version1(state) => state,
     })

--- a/rustual-boy-serialization/src/serde_ibytes.rs
+++ b/rustual-boy-serialization/src/serde_ibytes.rs
@@ -1,0 +1,31 @@
+use std::{mem, slice};
+use serde_bytes::ByteBuf;
+use serde::{Serializer, Deserializer, Deserialize};
+
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where T: From<Vec<i8>>,
+          D: Deserializer<'de>
+{
+    ByteBuf::deserialize(deserializer).map(|buf| {
+        let mut u8_v: Vec<u8> = buf.into();
+
+        let i8_v = unsafe {
+            Vec::from_raw_parts(
+                u8_v.as_mut_ptr() as *mut i8,
+                u8_v.len(),
+                u8_v.capacity()
+            )
+        };
+        mem::forget(u8_v);
+        i8_v.into()
+    })
+}
+
+pub fn serialize<T, S>(bytes: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where T: ?Sized + AsRef<[i8]>,
+          S: Serializer
+{
+    let i8_s: &[i8] = bytes.as_ref();
+    let u8_s: &[u8] = unsafe { slice::from_raw_parts(i8_s.as_ptr() as *const u8, i8_s.len()) };
+    serializer.serialize_bytes(u8_s)
+}

--- a/rustual-boy-serialization/src/version1.rs
+++ b/rustual-boy-serialization/src/version1.rs
@@ -1,4 +1,39 @@
 use std::collections::HashSet;
+use serde_bytes;
+
+mod serde_ibytes {
+    use std::{mem, slice};
+    use serde_bytes::ByteBuf;
+    use serde::{Serializer, Deserializer, Deserialize};
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+	where T: From<Vec<i8>>,
+	      D: Deserializer<'de>
+    {
+	ByteBuf::deserialize(deserializer).map(|buf| {
+            let mut u8_v: Vec<u8> = buf.into();
+
+            let i8_v = unsafe {
+                Vec::from_raw_parts(
+                    u8_v.as_mut_ptr() as *mut i8,
+                    u8_v.len(),
+                    u8_v.capacity()
+                )
+            };
+            mem::forget(u8_v);
+            i8_v.into()
+        })
+    }
+
+    pub fn serialize<T, S>(bytes: &T, serializer: S) -> Result<S::Ok, S::Error>
+        where T: ?Sized + AsRef<[i8]>,
+              S: Serializer
+    {
+        let i8_s: &[i8] = bytes.as_ref();
+        let u8_s: &[u8] = unsafe { slice::from_raw_parts(i8_s.as_ptr() as *const u8, i8_s.len()) };
+        serializer.serialize_bytes(u8_s)
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct State {
@@ -8,7 +43,9 @@ pub struct State {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct InterconnectState {
+    #[serde(with = "serde_bytes")]
     pub rom: Box<[u8]>,
+    #[serde(with = "serde_bytes")]
     pub wram: Box<[u8]>,
     pub sram: SramState,
     pub vip: VipState,
@@ -48,6 +85,7 @@ pub struct GamePadState {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SramState {
+    #[serde(with = "serde_bytes")]
     pub bytes: Box<[u8]>,
 
     pub size: usize,
@@ -88,6 +126,7 @@ pub enum DrawingStateState {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct VipState {
+    #[serde(with = "serde_bytes")]
     pub vram: Box<[u8]>,
 
     pub display_state: DisplayStateState,
@@ -250,7 +289,9 @@ pub struct NoiseSoundState {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct VsuState {
+    #[serde(with = "serde_bytes")]
     pub waveform_data: Box<[u8]>,
+    #[serde(with = "serde_ibytes")]
     pub mod_data: Box<[i8]>,
 
     pub sound1: StandardSoundState,

--- a/rustual-boy-serialization/src/version1.rs
+++ b/rustual-boy-serialization/src/version1.rs
@@ -1,39 +1,6 @@
 use std::collections::HashSet;
 use serde_bytes;
-
-mod serde_ibytes {
-    use std::{mem, slice};
-    use serde_bytes::ByteBuf;
-    use serde::{Serializer, Deserializer, Deserialize};
-
-    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
-	where T: From<Vec<i8>>,
-	      D: Deserializer<'de>
-    {
-	ByteBuf::deserialize(deserializer).map(|buf| {
-            let mut u8_v: Vec<u8> = buf.into();
-
-            let i8_v = unsafe {
-                Vec::from_raw_parts(
-                    u8_v.as_mut_ptr() as *mut i8,
-                    u8_v.len(),
-                    u8_v.capacity()
-                )
-            };
-            mem::forget(u8_v);
-            i8_v.into()
-        })
-    }
-
-    pub fn serialize<T, S>(bytes: &T, serializer: S) -> Result<S::Ok, S::Error>
-        where T: ?Sized + AsRef<[i8]>,
-              S: Serializer
-    {
-        let i8_s: &[i8] = bytes.as_ref();
-        let u8_s: &[u8] = unsafe { slice::from_raw_parts(i8_s.as_ptr() as *const u8, i8_s.len()) };
-        serializer.serialize_bytes(u8_s)
-    }
-}
+use serde_ibytes;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct State {


### PR DESCRIPTION
Because libretro has an API that asks for the size seperately, and we
have to serialize to get the size, the end result is that we change from
2 serializations for each save state down to 1.